### PR TITLE
relax `azure-synapse-spark` dependency version with bug fixes

### DIFF
--- a/feathr_project/feathr/_synapse_submission.py
+++ b/feathr_project/feathr/_synapse_submission.py
@@ -21,7 +21,7 @@ from feathr._abc import SparkJobLauncher
 from feathr.constants import *
 
 class LivyStates(Enum):
-    """ Copy LivyStates over to relax the dependency for azure-synapse-spark pacakge.
+    """ Adapt LivyStates over to relax the dependency for azure-synapse-spark pacakge.
     Definition is here:
     https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/synapse/azure-synapse-spark/azure/synapse/spark/models/_spark_client_enums.py#L38
     """
@@ -129,9 +129,9 @@ class _FeathrSynapseJobLauncher(SparkJobLauncher):
         while (timeout_seconds is None) or (time.time() - start_time < timeout_seconds):
             status = self.get_status()
             logger.info('Current Spark job status: {}', status)
-            if status in {LivyStates.SUCCESS}:
+            if status in {LivyStates.SUCCESS.value}:
                 return True
-            elif status in {LivyStates.ERROR, LivyStates.DEAD, LivyStates.KILLED}:
+            elif status in {LivyStates.ERROR.value, LivyStates.DEAD.value, LivyStates.KILLED.value}:
                 return False
             else:
                 time.sleep(30)

--- a/feathr_project/feathr/_synapse_submission.py
+++ b/feathr_project/feathr/_synapse_submission.py
@@ -6,19 +6,37 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 from os.path import basename
+from enum import Enum
 
 from azure.identity import (ChainedTokenCredential, DefaultAzureCredential,
                             DeviceCodeCredential, EnvironmentCredential,
                             ManagedIdentityCredential)
 from azure.storage.filedatalake import DataLakeServiceClient
 from azure.synapse.spark import SparkClient
-from azure.synapse.spark.models import (LivyStates, SparkBatchJob,
-                                        SparkBatchJobOptions)
+from azure.synapse.spark.models import SparkBatchJobOptions
 from loguru import logger
 from tqdm import tqdm
 
 from feathr._abc import SparkJobLauncher
 from feathr.constants import *
+
+class LivyStates(Enum):
+    """ Copy LivyStates over to relax the dependency for azure-synapse-spark pacakge.
+    Definition is here:
+    https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/synapse/azure-synapse-spark/azure/synapse/spark/models/_spark_client_enums.py#L38
+    """
+
+    NOT_STARTED = "not_started"
+    STARTING = "starting"
+    IDLE = "idle"
+    BUSY = "busy"
+    SHUTTING_DOWN = "shutting_down"
+    ERROR = "error"
+    DEAD = "dead"
+    KILLED = "killed"
+    SUCCESS = "success"
+    RUNNING = "running"
+    RECOVERING = "recovering"
 
 
 class _FeathrSynapseJobLauncher(SparkJobLauncher):

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -91,7 +91,9 @@ class FeathrClient(object):
         if local_workspace_dir:
             self.local_workspace_dir = local_workspace_dir
         else:
-            self.local_workspace_dir = tempfile.TemporaryDirectory().name
+            # this is required for Windows
+            tem_dir_obj = tempfile.TemporaryDirectory()
+            self.local_workspace_dir = tem_dir_obj.name
 
         self.envutils = envutils
 

--- a/feathr_project/feathrcli/data/feathr_user_workspace/features/agg_features.py
+++ b/feathr_project/feathrcli/data/feathr_user_workspace/features/agg_features.py
@@ -6,7 +6,7 @@ from feathr.transformation import WindowAggTransformation
 from feathr.typed_key import TypedKey
 
 batch_source = HdfsSource(name="nycTaxiBatchSource",
-                          path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                          path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                           event_timestamp_column="lpep_dropoff_datetime",
                           timestamp_format="yyyy-MM-dd HH:mm:ss")
 

--- a/feathr_project/feathrcli/data/feathr_user_workspace/features/non_agg_features.py
+++ b/feathr_project/feathrcli/data/feathr_user_workspace/features/non_agg_features.py
@@ -5,7 +5,7 @@ from feathr.typed_key import TypedKey
 from feathr.source import HdfsSource
 
 batch_source = HdfsSource(name="nycTaxiBatchSource",
-                          path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                          path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                           event_timestamp_column="lpep_dropoff_datetime",
                           timestamp_format="yyyy-MM-dd HH:mm:ss")
 

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         'Click',
         "azure-storage-file-datalake>=12.5.0",
-        "azure-synapse-spark>=0.7.0",
+        "azure-synapse-spark",
         "azure-identity",
         "py4j",
         "loguru",

--- a/feathr_project/test/test_azure_snowflake_e2e.py
+++ b/feathr_project/test/test_azure_snowflake_e2e.py
@@ -31,7 +31,7 @@ def test_feathr_online_store_agg_features():
     client.materialize_features(settings)
     # just assume the job is successful without validating the actual result in Redis. Might need to consolidate
     # this part with the test_feathr_online_store test case
-    client.wait_job_to_finish(timeout_sec=600)
+    client.wait_job_to_finish(timeout_sec=900)
 
     res = client.get_online_features('snowflakeSampleDemoFeature', '1',
                                      ['f_snowflake_call_center_division_name', 'f_snowflake_call_center_zipcode'])

--- a/feathr_project/test/test_azure_spark_e2e.py
+++ b/feathr_project/test/test_azure_spark_e2e.py
@@ -44,7 +44,7 @@ def test_feathr_online_store_agg_features():
     client.materialize_features(settings)
     # just assume the job is successful without validating the actual result in Redis. Might need to consolidate
     # this part with the test_feathr_online_store test case
-    client.wait_job_to_finish(timeout_sec=600)
+    client.wait_job_to_finish(timeout_sec=900)
 
     res = client.get_online_features(online_test_table, '265', [
                                      'f_location_avg_fare', 'f_location_max_fare'])
@@ -85,7 +85,7 @@ def test_feathr_online_store_non_agg_features():
     client.materialize_features(settings)
     # just assume the job is successful without validating the actual result in Redis. Might need to consolidate
     # this part with the test_feathr_online_store test case
-    client.wait_job_to_finish(timeout_sec=600)
+    client.wait_job_to_finish(timeout_sec=900)
 
     res = client.get_online_features(online_test_table, '111', ['f_gen_trip_distance', 'f_gen_is_long_trip_distance',
                                                                    'f1', 'f2', 'f3', 'f4', 'f5', 'f6'])

--- a/feathr_project/test/test_azure_spark_e2e.py
+++ b/feathr_project/test/test_azure_spark_e2e.py
@@ -148,7 +148,7 @@ def test_feathr_get_offline_features():
         feature_query = FeatureQuery(
             feature_list=["f_location_avg_fare"], key=location_id)
         settings = ObservationSettings(
-            observation_path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+            observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
             event_timestamp_column="lpep_dropoff_datetime",
             timestamp_format="yyyy-MM-dd HH:mm:ss")
 

--- a/feathr_project/test/test_feature_anchor.py
+++ b/feathr_project/test/test_feature_anchor.py
@@ -60,7 +60,7 @@ def test_request_feature_anchor_to_config():
 
 def test_non_agg_feature_anchor_to_config():
     batch_source = HdfsSource(name="nycTaxiBatchSource",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
 
@@ -111,7 +111,7 @@ def test_non_agg_feature_anchor_to_config():
 
 def test_agg_anchor_to_config():
     batch_source = HdfsSource(name="nycTaxiBatchSource",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
 

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -18,7 +18,7 @@ def basic_test_setup(config_path: str):
     
     client = FeathrClient(config_path=config_path)
     batch_source = HdfsSource(name="nycTaxiBatchSource",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
 
@@ -135,7 +135,7 @@ def registry_test_setup(config_path: str):
         return df
 
     batch_source = HdfsSource(name="nycTaxiBatchSource",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss",
                               preprocessing=add_new_dropoff_and_fare_amount_column,

--- a/feathr_project/test/test_observation_setting.py
+++ b/feathr_project/test/test_observation_setting.py
@@ -3,7 +3,7 @@ from feathr.settings import ObservationSettings
 
 def test_observation_setting_with_timestamp():
     observation_settings = ObservationSettings(
-        observation_path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+        observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
         event_timestamp_column="lpep_dropoff_datetime",
         timestamp_format="yyyy-MM-dd HH:mm:ss")
     config = observation_settings.to_config()
@@ -17,7 +17,7 @@ def test_observation_setting_with_timestamp():
                 }
             }
             
-            observationPath: "abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv"
+            observationPath: "wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv"
         """
     assert ''.join(config.split()) == ''.join(expected_config.split())
 

--- a/feathr_project/test/test_pyduf_preprocessing_e2e.py
+++ b/feathr_project/test/test_pyduf_preprocessing_e2e.py
@@ -337,7 +337,7 @@ def test_get_offline_feature_two_swa_with_diff_preprocessing():
                                )
 
     swa_source_3 = HdfsSource(name="nycTaxiBatchSource3",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04_old.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04_old.csv",
                               preprocessing=add_old_lpep_dropoff_datetime,
                               event_timestamp_column="old_lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")

--- a/feathr_project/test/test_pyduf_preprocessing_e2e.py
+++ b/feathr_project/test/test_pyduf_preprocessing_e2e.py
@@ -59,7 +59,7 @@ def test_non_swa_feature_gen_with_offline_preprocessing():
     client = basic_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
 
     batch_source = HdfsSource(name="nycTaxiBatchSource_add_new_fare_amount",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               preprocessing=add_new_fare_amount,
                               event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
@@ -118,7 +118,7 @@ def test_feature_swa_feature_gen_with_preprocessing():
     client = basic_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
 
     batch_source = HdfsSource(name="nycTaxiBatchSource",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               preprocessing=add_new_dropoff_and_fare_amount_column,
                               event_timestamp_column="new_lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
@@ -180,14 +180,14 @@ def test_feathr_get_offline_features_hdfs_source():
     client = basic_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
 
     batch_source1 = HdfsSource(name="nycTaxiBatchSource_add_new_dropoff_and_fare_amount_column",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               preprocessing=add_new_dropoff_and_fare_amount_column,
                               event_timestamp_column="new_lpep_dropoff_datetime",
                               # event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
 
     batch_source2 = HdfsSource(name="nycTaxiBatchSource_add_new_fare_amount",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               preprocessing=add_new_fare_amount,
                               event_timestamp_column="lpep_dropoff_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
@@ -248,7 +248,7 @@ def test_feathr_get_offline_features_hdfs_source():
     ]
 
     settings = ObservationSettings(
-        observation_path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+        observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
         event_timestamp_column="lpep_dropoff_datetime",
         timestamp_format="yyyy-MM-dd HH:mm:ss")
 
@@ -281,7 +281,7 @@ def test_get_offline_feature_two_swa_with_diff_preprocessing():
     client = basic_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
 
     swa_source_1 = HdfsSource(name="nycTaxiBatchSource1",
-                               path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                               path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                                preprocessing=add_new_dropoff_and_fare_amount_column,
                                event_timestamp_column="new_lpep_dropoff_datetime",
                                timestamp_format="yyyy-MM-dd HH:mm:ss")
@@ -313,7 +313,7 @@ def test_get_offline_feature_two_swa_with_diff_preprocessing():
 
 
     swa_source_2 = HdfsSource(name="nycTaxiBatchSource2",
-                              path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+                              path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
                               preprocessing=add_new_surcharge_amount_and_pickup_column,
                               event_timestamp_column="new_lpep_pickup_datetime",
                               timestamp_format="yyyy-MM-dd HH:mm:ss")
@@ -365,7 +365,7 @@ def test_get_offline_feature_two_swa_with_diff_preprocessing():
     ]
 
     settings = ObservationSettings(
-        observation_path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/green_tripdata_2020-04.csv",
+        observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
         event_timestamp_column="lpep_dropoff_datetime",
         timestamp_format="yyyy-MM-dd HH:mm:ss")
 

--- a/feathr_project/test/test_pyduf_preprocessing_e2e.py
+++ b/feathr_project/test/test_pyduf_preprocessing_e2e.py
@@ -103,7 +103,7 @@ def test_non_swa_feature_gen_with_offline_preprocessing():
     client.materialize_features(settings)
     # just assume the job is successful without validating the actual result in Redis. Might need to consolidate
     # this part with the test_feathr_online_store test case
-    client.wait_job_to_finish(timeout_sec=600)
+    client.wait_job_to_finish(timeout_sec=900)
 
     res = client.get_online_features(online_test_table, '2020-04-01 07:21:51', [
         'f_is_long_trip_distance', 'f_day_of_week'])
@@ -165,7 +165,7 @@ def test_feature_swa_feature_gen_with_preprocessing():
     client.materialize_features(settings)
     # just assume the job is successful without validating the actual result in Redis. Might need to consolidate
     # this part with the test_feathr_online_store test case
-    client.wait_job_to_finish(timeout_sec=600)
+    client.wait_job_to_finish(timeout_sec=900)
 
     res = client.get_online_features(online_test_table, '265', ['f_location_avg_fare', 'f_location_max_fare'])
     assert res == [1000041.625, 1000100.0]


### PR DESCRIPTION
This PR solves the following issues:
1. Currently, Feathr is relying on `azure-synapse-spark` latest package (0.7.0) because Feathr needs to use `LivyState` enum.  However azure-cli has a different dependency for `azure-synapse-spark` and installing both will cause conflicts. This PR addresses the issue by lowering the `azure-synapse-spark` dependency and copied `LivyState` enum.
2. Fix a small bug where creating temp folders will fail on Windows
3. Fix test failures by using public data source