### PR TITLE
Updating the CI Pipeline to allow specially labelled PRs to execute tests

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,22 +12,16 @@ on:
       - 'docs/**'
       - '**/README.md'
   pull_request_target:
-    types: [labeled]
-    paths-ignore:
-      - 'docs/**'
-      - '**/README.md'
-
-
+     types: [labeled]
+     paths-ignore:
+       - 'docs/**'
+       - '**/README.md'
 jobs:
   sbt_test:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v2
-        with:
-          # pull_request_target runs the workflow in the context of the base repo so we need to configure it here
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          submodules: recursive
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -60,10 +54,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v2
-        with:
-          # pull_request_target runs the workflow in the context of the base repo so we need to configure it here
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          submodules: recursive
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -90,7 +80,8 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set env variable and upload jars
         env:
-          DATABRICKS_HOST: "https://adb-2474129336842816.16.azuredatabricks.net/"
+          # set this for databricks CLI
+          DATABRICKS_HOST: ${{secrets.DATABRICKS_HOST}}
           DATABRICKS_TOKEN: ${{secrets.DATABRICKS_WORKSPACE_TOKEN_VALUE}}
         run: |
           # overwrite corresponding environment variables to utilize feathr to upload the files
@@ -100,9 +91,9 @@ jobs:
         env:
           PROJECT_CONFIG__PROJECT_NAME: "feathr_github_ci_databricks"
           SPARK_CONFIG__SPARK_CLUSTER: databricks
-          SPARK_CONFIG__DATABRICKS__WORKSPACE_INSTANCE_URL: "https://adb-2474129336842816.16.azuredatabricks.net/"
+          SPARK_CONFIG__DATABRICKS__WORKSPACE_INSTANCE_URL: ${{secrets.DATABRICKS_HOST}}
           DATABRICKS_WORKSPACE_TOKEN_VALUE: ${{secrets.DATABRICKS_WORKSPACE_TOKEN_VALUE}}
-          SPARK_CONFIG__DATABRICKS__CONFIG_TEMPLATE: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","num_workers":2,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"},"instance_pool_id":"0403-214809-inlet434-pool-l9dj3kwz"},"libraries":[{"jar":"FEATHR_FILL_IN"}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
+          SPARK_CONFIG__DATABRICKS__CONFIG_TEMPLATE: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","num_workers":2,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"},"instance_pool_id":"${{secrets.DATABRICKS_INSTANCE_POOL_ID}}"},"libraries":[{"jar":"FEATHR_FILL_IN"}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
           REDIS_PASSWORD: ${{secrets.REDIS_PASSWORD}}
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
           AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
@@ -126,10 +117,6 @@ jobs:
       if: contains(github.event.pull_request.labels.*.name, 'safe to test')
       steps:
       - uses: actions/checkout@v2
-        with:
-          # pull_request_target runs the workflow in the context of the base repo so we need to configure it here
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-          submodules: recursive
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -186,4 +173,5 @@ jobs:
           # skip databricks related test as we just ran the test; also seperate databricks and synapse test to make sure there's no write conflict
           # run in 4 parallel jobs to make the time shorter
           pytest -n 4
+
 

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -11,12 +11,23 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/README.md'
+  pull_request_target:
+    types: [labeled]
+    paths-ignore:
+      - 'docs/**'
+      - '**/README.md'
+
 
 jobs:
   sbt_test:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v2
+        with:
+          # pull_request_target runs the workflow in the context of the base repo so we need to configure it here
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          submodules: recursive
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -26,6 +37,7 @@ jobs:
         run: sbt clean && sbt test
   python_lint:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -45,8 +57,13 @@ jobs:
       
   databricks_test:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
     steps:
       - uses: actions/checkout@v2
+        with:
+          # pull_request_target runs the workflow in the context of the base repo so we need to configure it here
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          submodules: recursive
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -73,8 +90,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set env variable and upload jars
         env:
-          # set this for databricks CLI
-          DATABRICKS_HOST: ${{secrets.DATABRICKS_HOST}}
+          DATABRICKS_HOST: "https://adb-2474129336842816.16.azuredatabricks.net/"
           DATABRICKS_TOKEN: ${{secrets.DATABRICKS_WORKSPACE_TOKEN_VALUE}}
         run: |
           # overwrite corresponding environment variables to utilize feathr to upload the files
@@ -84,9 +100,9 @@ jobs:
         env:
           PROJECT_CONFIG__PROJECT_NAME: "feathr_github_ci_databricks"
           SPARK_CONFIG__SPARK_CLUSTER: databricks
-          SPARK_CONFIG__DATABRICKS__WORKSPACE_INSTANCE_URL: ${{secrets.DATABRICKS_HOST}}
+          SPARK_CONFIG__DATABRICKS__WORKSPACE_INSTANCE_URL: "https://adb-2474129336842816.16.azuredatabricks.net/"
           DATABRICKS_WORKSPACE_TOKEN_VALUE: ${{secrets.DATABRICKS_WORKSPACE_TOKEN_VALUE}}
-          SPARK_CONFIG__DATABRICKS__CONFIG_TEMPLATE: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","num_workers":2,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"},"instance_pool_id":"${{secrets.DATABRICKS_INSTANCE_POOL_ID}}"},"libraries":[{"jar":"FEATHR_FILL_IN"}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
+          SPARK_CONFIG__DATABRICKS__CONFIG_TEMPLATE: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","num_workers":2,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"},"instance_pool_id":"0403-214809-inlet434-pool-l9dj3kwz"},"libraries":[{"jar":"FEATHR_FILL_IN"}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
           REDIS_PASSWORD: ${{secrets.REDIS_PASSWORD}}
           AZURE_CLIENT_ID: ${{secrets.AZURE_CLIENT_ID}}
           AZURE_TENANT_ID: ${{secrets.AZURE_TENANT_ID}}
@@ -107,8 +123,13 @@ jobs:
   azure_synapse_test:
       # might be a bit duplication to setup both the azure_synapse test and databricks test, but for now we will keep those to accelerate the test speed
       runs-on: ubuntu-latest
+      if: contains(github.event.pull_request.labels.*.name, 'safe to test')
       steps:
       - uses: actions/checkout@v2
+        with:
+          # pull_request_target runs the workflow in the context of the base repo so we need to configure it here
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          submodules: recursive
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
@@ -165,5 +186,4 @@ jobs:
           # skip databricks related test as we just ran the test; also seperate databricks and synapse test to make sure there's no write conflict
           # run in 4 parallel jobs to make the time shorter
           pytest -n 4
-
 


### PR DESCRIPTION
The changes in this pull request allows incoming from a forked repo and which is labelled by repository contributors as "safe to test" to be able to execute the test by having access to test infrastructure.  

The label needs to be assigned very cautiously to PRs, specially for external contributions.

Following are the repository roles for an organization. From least access to most access, the roles for an organization repository are. External contributors will only have read access.

- Read: Recommended for non-code contributors who want to view or discuss your project
- Triage: Recommended for contributors who need to proactively manage issues and pull requests without write access
- Write: Recommended for contributors who actively push to your project
- Maintain: Recommended for project managers who need to manage the repository without access to sensitive or destructive actions
- Admin: Recommended for people who need full access to the project, including sensitive and destructive actions like managing security or deleting a repository