### PR TITLE
Fix corner case when registering derived features

### DIFF
--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -303,16 +303,16 @@ class _FeatureRegistry():
         for derived_feature in derived_features:
             # make sure the input is derived feature
             if isinstance(derived_feature, DerivedFeature):
+                # add this derived feature in the topo sort graph without any precessesors
+                # since regardless we need it
+                ts.add(derived_feature)
                 for input_feature in derived_feature.input_features:
                     if isinstance(input_feature, DerivedFeature):
                         # `input_feature` is predecessor of `derived_feature`
                         ts.add(derived_feature, input_feature)
                         self._add_all_derived_features(input_feature.input_features, ts)
-                    else:
-                        # the input feature is not a derived feature; it's an anchor feature
-                        # just add the derived feature without predecessors 
-                        # since this derived feature is calculated based only on anchor features
-                        ts.add(derived_feature)
+
+                        
 
 
     def _parse_derived_features(self, derived_features: List[DerivedFeature]) -> List[AtlasEntity]:

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -308,6 +308,11 @@ class _FeatureRegistry():
                         # `input_feature` is predecessor of `derived_feature`
                         ts.add(derived_feature, input_feature)
                         self._add_all_derived_features(input_feature.input_features, ts)
+                    else:
+                        # the input feature is not a derived feature; it's an anchor feature
+                        # just add the derived feature without predecessors 
+                        # since this derived feature is calculated based only on anchor features
+                        ts.add(derived_feature)
 
 
     def _parse_derived_features(self, derived_features: List[DerivedFeature]) -> List[AtlasEntity]:

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -310,6 +310,9 @@ class _FeatureRegistry():
                     if isinstance(input_feature, DerivedFeature):
                         # `input_feature` is predecessor of `derived_feature`
                         ts.add(derived_feature, input_feature)
+                        # if any of the input feature is a derived feature, have this recursive call
+                        # use this for code simplicity. 
+                        # if the amount of features is huge, consider only add the derived features into the function call
                         self._add_all_derived_features(input_feature.input_features, ts)
 
                         

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -25,6 +25,8 @@ def test_feathr_register_features_e2e():
     assert 'f_is_long_trip_distance' in all_features # test regular ones
     assert 'f_trip_time_rounded' in all_features # make sure derived features are there
     assert 'f_location_avg_fare' in all_features # make sure aggregated features are there
+    assert 'f_trip_time_rounded_plus' in all_features # make sure derived features are there 
+    assert 'f_trip_time_distance' in all_features # make sure derived features are there  
 
 @pytest.mark.skip(reason="Add back get_features is not supported in feature registry for now and needs further discussion")
 def test_feathr_get_features_from_registry():

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -127,7 +127,7 @@ def snowflake_test_setup(config_path: str):
 def registry_test_setup(config_path: str):
 
 
-    # use a new project name every time to make sure if all features are registered correctly no
+    # use a new project name every time to make sure all features are registered correctly
     now = datetime.now()
     os.environ["project_config__project_name"] =  ''.join(['feathr_ci','_', str(now.minute), '_', str(now.second), '_', str(now.microsecond)]) 
 

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -127,6 +127,10 @@ def snowflake_test_setup(config_path: str):
 def registry_test_setup(config_path: str):
 
 
+    # use a new project name every time to make sure if all features are registered correctly no
+    now = datetime.now()
+    os.environ["project_config__project_name"] =  ''.join(['feathr_ci','_', str(now.minute), '_', str(now.second), '_', str(now.microsecond)]) 
+
     client = FeathrClient(config_path=config_path, project_registry_tag={"for_test_purpose":"true"})
 
     def add_new_dropoff_and_fare_amount_column(df: DataFrame):


### PR DESCRIPTION
Currently if a derived feature is only based on anchor features, it will not be registered correctly. This PR solves the issue (also test updated to prevent this issue in the future)