### PR TITLE
Windoze/udf improve

### DIFF
--- a/feathr_project/feathr/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/_preprocessing_pyudf_manager.py
@@ -64,8 +64,6 @@ class _PreprocessingPyudfManager(object):
 
     @staticmethod
     def persist_pyspark_udf_to_file(source_name, user_func, local_workspace_dir):
-        if not hasattr(user_func, "__name__") or getattr(user_func, "__name__")=='<lambda>':
-            raise ValueError("Using Lambda as UDF is not supported.")
         # the UDF callable is stored in `__feathr_user_functions` dictionary with source name as the key,
         # and the body is packed by cloudpickle.
         # so the final source line is like:


### PR DESCRIPTION
Use `cloudpickle` to save and load UDF, to support complex callable objects such as functions with dependencies, lambdas, callable classes, etc.
Choosing `cloudpickle` is because this package is shipped within PySpark so we don't need to involve additional dependencies.