### PR TITLE
Fix installation issues for Databricks ML env

### DIFF
--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -44,7 +44,8 @@ setup(
         "google-api-python-client>=2.41.0",
         "azure-keyvault-secrets",
         "confluent-kafka",
-        "avro"
+        "avro",
+        "azure-core<=1.22.1"
     ],
     tests_require=[
         'pytest',

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -45,6 +45,10 @@ setup(
         "azure-keyvault-secrets",
         "confluent-kafka",
         "avro",
+        # In 1.23.0, azure-core is using ParamSpec which might cause issues in some of the databricks runtime.
+        # see this for more details:
+        # https://github.com/Azure/azure-sdk-for-python/pull/22891
+        # using a version lower than that to workaround this issue
         "azure-core<=1.22.1"
     ],
     tests_require=[

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -49,7 +49,8 @@ setup(
         # see this for more details:
         # https://github.com/Azure/azure-sdk-for-python/pull/22891
         # using a version lower than that to workaround this issue
-        "azure-core<=1.22.1"
+        "azure-core<=1.22.1",
+        "typing_extensions>=4.2.0"
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
seems caused by a recently added param spec reference:
related issue: https://github.com/Azure/azure-sdk-for-python/issues/23697

ParamSpec is added in 3.10:
https://docs.python.org/3/library/typing.html#typing.ParamSpec

and seems caused by this PR in azure-core:
https://github.com/Azure/azure-sdk-for-python/pull/22891


Issue here: https://github.com/linkedin/feathr/issues/154