### PR TITLE
Enable get features from registry

### DIFF
--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -836,7 +836,7 @@ derivations: {
             else:
                 # otherwise append all the entities
                 guid_list.append(entity["id"])
-        entity_res = [] if guid_list is None else self.purview_client.get_entity(
+        entity_res = [] if guid_list is None or len(guid_list)==0 else self.purview_client.get_entity(
             guid=guid_list)["entities"]
         return entity_res
         

--- a/feathr_project/feathr/anchor.py
+++ b/feathr_project/feathr/anchor.py
@@ -41,9 +41,7 @@ class FeatureAnchor(HoconConvertible):
                 if feature.key == [DUMMY_KEY]:
                     raise RuntimeError(f"For anchors of non-INPUT_CONTEXT source, key of feature {feature.name} "
                                        f"should be explicitly specified and not left blank.")
-        for feature in self.features:
-            assert feature.key_alias == self.features[0].key_alias
-
+        
     def to_feature_config(self) -> str:
         tm = Template("""
             {{anchor_name}}: {

--- a/feathr_project/feathr/api/api.py
+++ b/feathr_project/feathr/api/api.py
@@ -118,9 +118,9 @@ def get_feature_qualifiedName(code : str, project_name: str, feature_name: str, 
         registry = getRegistry()
         logger.info("Retrieved registry client successfully")
         response.status_code = status.HTTP_200_OK
-        guid = registry.get_feature_guid(feature_name)
-        if guid:
-            result = registry.get_feature_lineage(guid)
+        id = registry.get_feature_id(feature_name)
+        if id:
+            result = registry.get_feature_lineage(id)
             return result
     except AtlasException as ae:
         logger.error("Error retrieving feature: %s", ae.args[0])

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -699,3 +699,9 @@ class FeathrClient(object):
             KAFKA_SASL_JAAS_CONFIG: "{sasl}"
             """.format(sasl=sasl)
         return config_str
+
+    def get_features_from_registry(self,project_name):
+        """
+        Get feature from registry by project name
+        """
+        return self.registry.get_features_from_registry(project_name)

--- a/feathr_project/feathr/feature.py
+++ b/feathr_project/feathr/feature.py
@@ -42,7 +42,8 @@ class FeatureBase(HoconConvertible):
         else:
             self.transform = transform
         # An alias for the key in this feature. Default to its key column alias. Useful in derived features.
-        self.key_alias = [k.key_column_alias for k in self.key]
+        # self.key could be null, when getting features from registry.
+        self.key_alias = [k.key_column_alias for k in self.key if k]
 
     def with_key(self, key_alias: Union[str, List[str]]):
         """Rename the feature key with the alias. This is useful in derived features that depends on

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -2,6 +2,8 @@ import glob
 import os
 import time
 from pathlib import Path
+from feathr.anchor import FeatureAnchor
+from feathr.feature_derivations import DerivedFeature
 
 import pytest
 from click.testing import CliRunner
@@ -89,7 +91,25 @@ def test_get_feature_from_registry():
     inputs = registry.search_input_anchor_features(['hierarchical_derived_feature'],entity_array_to_dict(anchors+[derived_feature_with_multiple_inputs,hierarchical_derived_feature]))
     assert len(inputs)==3
     assert "input_anchorA" in inputs and "input_anchorB" in inputs and "input_anchorC" in inputs
-    
+
+def test_feathr_get_sample_features_from_registry():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(init, [])
+
+        os.chdir('feathr_user_workspace')
+        
+        client = FeathrClient()
+        # Sync workspace from registry, will get all conf files back
+        features = client.get_features_from_registry("feathr_github_ci_synapse")
+        assert len(features)==2
+        assert isinstance(features[0][0],FeatureAnchor)
+        assert isinstance(features[1][0],DerivedFeature)
+
+        assert len(features[0])==2
+        assert len(features[1])==2
+
+
 @pytest.mark.skip(reason="Add back get_features is not supported in feature registry for now and needs further discussion")
 def test_feathr_get_features_from_registry():
     """
@@ -115,3 +135,5 @@ def test_feathr_get_features_from_registry():
         # we should have at least 3 conf files
         assert len(total_conf_files) == 3
 
+
+    


### PR DESCRIPTION
Add new function to feature registry to fetch anchor features and derived features.
related issue : https://github.com/linkedin/feathr/issues/186

The goal is trying to get features from registry  (fetched from purview sdk for now), and perform transformations and enrichment, transform the purview object into list of FeatureAnchor and DerivedFeature.

With the transformation completed, return values could be fed into feathr client for further operations (like build features)
