### PR TITLE
[feathr] Move pyspark into test requires

### DIFF
--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -36,7 +36,6 @@ setup(
         "Jinja2",
         "tqdm",
         "pyarrow",
-        "pyspark>=3.1.2",
         "python-snappy",
         "deltalake",
         "google>=3.0.0",
@@ -55,6 +54,7 @@ setup(
     ],
     tests_require=[
         'pytest',
+        "pyspark>=3.1.2",
     ],
     entry_points={
         'console_scripts': ['feathr=feathrcli.cli:cli']


### PR DESCRIPTION
Most users with Azure already have pyspark dependency and pyspark is pretty large. So take it out from dependency and move to test for now.