### PR TITLE
Use extra_package for `pyspark`

### DIFF
--- a/.github/workflows/main_merge_e2e.yml
+++ b/.github/workflows/main_merge_e2e.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist databricks-cli
-          python -m pip install -e ./feathr_project/
+          python -m pip install -e ./feathr_project/[pyspark]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set env variable and upload jars
         env:
@@ -135,7 +135,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist
-          python -m pip install -e ./feathr_project/
+          python -m pip install -e ./feathr_project/[pyspark]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run Feathr with Azure Synapse
         env:

--- a/.github/workflows/main_merge_e2e.yml
+++ b/.github/workflows/main_merge_e2e.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist databricks-cli
-          python -m pip install -e ./feathr_project/[pyspark]
+          python -m pip install -e ./feathr_project/[all]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set env variable and upload jars
         env:
@@ -135,7 +135,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist
-          python -m pip install -e ./feathr_project/[pyspark]
+          python -m pip install -e ./feathr_project/[all]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run Feathr with Azure Synapse
         env:

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist databricks-cli
-          python -m pip install -e ./feathr_project/
+          python -m pip install -e ./feathr_project/[pyspark]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set env variable and upload jars
         env:
@@ -143,7 +143,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist
-          python -m pip install -e ./feathr_project/
+          python -m pip install -e ./feathr_project/[pyspark]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run Feathr with Azure Synapse
         env:

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist databricks-cli
-          python -m pip install -e ./feathr_project/[pyspark]
+          python -m pip install -e ./feathr_project/[all]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Set env variable and upload jars
         env:
@@ -143,7 +143,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-xdist
-          python -m pip install -e ./feathr_project/[pyspark]
+          python -m pip install -e ./feathr_project/[all]
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Run Feathr with Azure Synapse
         env:

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -36,7 +36,6 @@ setup(
         "Jinja2",
         "tqdm",
         "pyarrow",
-        "pyspark>=3.1.2",
         "python-snappy",
         "deltalake",
         "google>=3.0.0",
@@ -56,6 +55,9 @@ setup(
     tests_require=[
         'pytest',
     ],
+    extras_require={
+        'pyspark': ["pyspark>=3.1.2",],
+    },
     entry_points={
         'console_scripts': ['feathr=feathrcli.cli:cli']
     },

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -56,7 +56,7 @@ setup(
         'pytest',
     ],
     extras_require={
-        'pyspark': ["pyspark>=3.1.2",],
+        'all': ["pyspark>=3.1.2"]
     },
     entry_points={
         'console_scripts': ['feathr=feathrcli.cli:cli']


### PR DESCRIPTION
Goal of this PR is to remove pyspark dependency as an optional dependency, so customers can use 
`pip install feathr` to install feathr, 


and if they need pyspark in local environment, they can use
`pip install feathr[all]` to install feathr with pyspark and other dependencies
