### PR TITLE
Detect returned error and print accordingly

### DIFF
--- a/feathr_project/feathr/_databricks_submission.py
+++ b/feathr_project/feathr/_databricks_submission.py
@@ -182,8 +182,8 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
             elif status in {'INTERNAL_ERROR', 'FAILED', 'TIMEDOUT', 'CANCELED'}:
                 result = RunsApi(self.api_client).get_run_output(self.res_job_id)
                 # See here for the returned fields: https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/2.0/jobs#--response-structure-8
-                # print out logs and stack trace if the job is failed
-                logger.error("Feathr job is failed. Please visit this page to view error message: {}", self.job_url)
+                # print out logs and stack trace if the job has failed
+                logger.error("Feathr job has failed. Please visit this page to view error message: {}", self.job_url)
                 if "error" in result:
                     logger.error("Error Code: {}", result["error"])
                 if "error_trace" in result:

--- a/feathr_project/feathr/_databricks_submission.py
+++ b/feathr_project/feathr/_databricks_submission.py
@@ -184,8 +184,10 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
                 # See here for the returned fields: https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/2.0/jobs#--response-structure-8
                 # print out logs and stack trace if the job is failed
                 logger.error("Feathr job is failed. Please visit this page to view error message: {}", self.job_url)
-                logger.error("Error Code: {}", result["error"])
-                logger.error("{}", result["error_trace"])
+                if "error" in result:
+                    logger.error("Error Code: {}", result["error"])
+                if "error_trace" in result:
+                    logger.error("{}", result["error_trace"])
                 return False
             else:
                 time.sleep(30)


### PR DESCRIPTION
Previously, when we detect a databricks job is failed, we will print out the logs assuming there are `error` and `error_trace` field. This is probably not true in some of the cases so we need to make those print out in a conditional way.