### PR TITLE
Add 'sphinx.ext.napoleon' to docs/conf extensions

### DIFF
--- a/feathr_project/docs/conf.py
+++ b/feathr_project/docs/conf.py
@@ -49,6 +49,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx_rtd_theme',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
sphinx itself doesn't add newline for google/numpy style documentations.     'sphinx.ext.napoleon' extension add a newline to each line for those python doc style.

Before:
![image](https://user-images.githubusercontent.com/5482153/166087697-c54dffcb-dedb-4b5d-a411-06c7c7bc148b.png)

After:

![image](https://user-images.githubusercontent.com/5482153/166087676-9fbfaf1e-3235-4525-905a-a6ed9916e6a3.png)
