### PR TITLE
Refactoring python documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -157,3 +157,6 @@ Feathr has native integration with Azure and other cloud services, and here's th
 - [Feature Definition Troubleshooting Guide](how-to-guides/troubleshoot-feature-definition.md)
 - [Feathr Expression Language](how-to-guides/expression-language.md)
 - [Feathr Job Configuration](how-to-guides/feathr-job-configuration.md)
+
+## API Documentation
+- [Python API Documentation](https://feathr.readthedocs.io/en/latest/)

--- a/docs/concepts/feature-definition.md
+++ b/docs/concepts/feature-definition.md
@@ -28,13 +28,16 @@ batch_source = HdfsSource(name="nycTaxiBatchSource",
                           timestamp_format="yyyy-MM-dd HH:mm:ss")
 ```
 
-See the python documentation to get the details on each input column.
+See the [Python API documentation](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.source.HdfsSource) to get the details on each input column.
 
 ## Step2: Define Anchors and Features
 A feature is called an anchored feature when the feature is directly 
 extracted from the source data, rather than computed on top of other features. The latter case is called derived feature.
 
-Anchors are required in Feathr. Here is an sample:
+Check [Feature Python API documentation](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.feature.Feature)
+and [Anchor Python API documentation](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.anchor.FeatureAnchor) to see more details.
+
+Here is a sample:
 
 ```python
 f_trip_distance = Feature(name="f_trip_distance",
@@ -98,7 +101,7 @@ Feature(name="f_location_max_fare",
 ```
 
 
-Note that the `agg_func` should be any of these:
+Note that the `agg_func`([API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.aggregation.Aggregation)) should be any of these:
 
 | Aggregation Type | Input Type | Description |
 | --- | --- | --- |
@@ -122,7 +125,8 @@ request_anchor = FeatureAnchor(name="request_features",
 Note that if the data source is from the observation data, the `source` section should be `INPUT_CONTEXT` to indicate the source of those defined anchors.
 
 ## Step3: Derived Features Section
-Derived features are the features that are computed from other features. They could be computed from anchored features, or other derived features.
+Derived features([Python API documentation](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.feature_derivations.DerivedFeature)) 
+are the features that are computed from other features. They could be computed from anchored features, or other derived features.
 
 
 ```python

--- a/docs/concepts/feature-generation.md
+++ b/docs/concepts/feature-generation.md
@@ -46,6 +46,6 @@ client.wait_job_to_finish(timeout_sec=600)
 res = client.get_online_features('nycTaxiDemoFeature', '265', [
                                      'f_location_avg_fare', 'f_location_max_fare'])
 ```
-([client.get_online_features](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.get_online_features))
+([client.get_online_features API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.get_online_features))
 
 After we finish running the materialization job, we can get the online features by querying the feature name, with the corresponding keys. In the example above, we query the online features called `f_location_avg_fare` and `f_location_max_fare`, and query with a key `265` (which is the location ID).

--- a/docs/concepts/feature-generation.md
+++ b/docs/concepts/feature-generation.md
@@ -37,6 +37,7 @@ client.materialize_features(settings)
 ```
 ([BackfillTime API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.materialization_settings.BackfillTime),
 [client.materialize_features() API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.materialize_features))
+
 ## Consuming the online features
 
 ```python
@@ -46,4 +47,5 @@ res = client.get_online_features('nycTaxiDemoFeature', '265', [
                                      'f_location_avg_fare', 'f_location_max_fare'])
 ```
 ([client.get_online_features](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.get_online_features))
+
 After we finish running the materialization job, we can get the online features by querying the feature name, with the corresponding keys. In the example above, we query the online features called `f_location_avg_fare` and `f_location_max_fare`, and query with a key `265` (which is the location ID).

--- a/docs/concepts/feature-generation.md
+++ b/docs/concepts/feature-generation.md
@@ -18,6 +18,8 @@ settings = MaterializationSettings("nycTaxiMaterializationJob",
                                    feature_names=["f_location_avg_fare", "f_location_max_fare"])
 client.materialize_features(settings)
 ```
+([MaterializationSettings API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.materialization_settings.MaterializationSettings),
+[RedisSink API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.sink.RedisSink))
 
 In the above example, we define a Redis table called `nycTaxiDemoFeature` and materialize two features called `f_location_avg_fare` and `f_location_max_fare` to Redis.
 
@@ -33,7 +35,8 @@ settings = MaterializationSettings("nycTaxiMaterializationJob",
                                    backfill_time=backfill_time)
 client.materialize_features(settings)
 ```
-
+([BackfillTime API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.materialization_settings.BackfillTime),
+[client.materialize_features() API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.materialize_features))
 ## Consuming the online features
 
 ```python
@@ -42,5 +45,5 @@ client.wait_job_to_finish(timeout_sec=600)
 res = client.get_online_features('nycTaxiDemoFeature', '265', [
                                      'f_location_avg_fare', 'f_location_max_fare'])
 ```
-
+([client.get_online_features](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.get_online_features))
 After we finish running the materialization job, we can get the online features by querying the feature name, with the corresponding keys. In the example above, we query the online features called `f_location_avg_fare` and `f_location_max_fare`, and query with a key `265` (which is the location ID).

--- a/docs/concepts/feature-join.md
+++ b/docs/concepts/feature-join.md
@@ -70,7 +70,8 @@ client.get_offline_features(observation_settings=settings,
                             output_path="abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/output.avro")
 
 ```
-
+([ObservationSettings API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.settings.ObservationSettings), 
+[client.get_offline_feature API doc](https://feathr.readthedocs.io/en/latest/feathr.html#feathr.client.FeathrClient.get_offline_features))
 
 After you have defined the features (as described in the [Feature Definition](feature-definition.md)) part, you can define how you want to join them.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -196,3 +196,4 @@ client.multi_get_online_features("nycTaxiDemoFeature", ["239", "265"], ['f_locat
 - Run the [demo notebook](https://github.com/linkedin/feathr/blob/main/feathr_project/feathrcli/data/feathr_user_workspace/nyc_driver_demo.ipynb) to understand the workflow of Feathr.
 - Read the [Feathr Documentation Page](https://linkedin.github.io/feathr/) page to understand the Feathr abstractions.
 - Read guide to understand [how to setup Feathr on Azure](../how-to-guides/azure-deployment.md).
+- Read [Python API Documentation](https://feathr.readthedocs.io/en/latest/)

--- a/feathr_project/docs/conf.py
+++ b/feathr_project/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'feathr'
+project = 'Feathr Feature Store'
 copyright = '2022, Feathr Community'
 author = 'Feathr Community'
 

--- a/feathr_project/docs/feathr.rst
+++ b/feathr_project/docs/feathr.rst
@@ -18,90 +18,19 @@ feathr.anchor module
     :show-inheritance:
 
 
-feathr.aggregation module
--------------------------
+feathr.source module
+--------------------
 
-.. automodule:: feathr.aggregation
+.. automodule:: feathr.source
     :members:
     :undoc-members:
     :show-inheritance:
 
-feathr.dtype module
--------------------
-
-.. automodule:: feathr.dtype
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.feathr\_configurations module
-------------------------------------
-
-.. automodule:: feathr.feathr_configurations
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 feathr.feature module
 ---------------------
 
 .. automodule:: feathr.feature
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.feature\_derivations module
-----------------------------------
-
-.. automodule:: feathr.feature_derivations
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.lookup\_feature module
------------------------------
-
-.. automodule:: feathr.lookup_feature
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.materialization\_settings module
----------------------------------------
-
-.. automodule:: feathr.materialization_settings
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.query\_feature\_list module
-----------------------------------
-
-.. automodule:: feathr.query_feature_list
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.settings module
-----------------------
-
-.. automodule:: feathr.settings
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.sink module
-------------------
-
-.. automodule:: feathr.sink
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-feathr.source module
---------------------
-
-.. automodule:: feathr.source
     :members:
     :undoc-members:
     :show-inheritance:
@@ -122,6 +51,77 @@ feathr.typed\_key module
     :undoc-members:
     :show-inheritance:
 
+feathr.aggregation module
+-------------------------
+
+.. automodule:: feathr.aggregation
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.dtype module
+-------------------
+
+.. automodule:: feathr.dtype
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.feature\_derivations module
+----------------------------------
+
+.. automodule:: feathr.feature_derivations
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.lookup\_feature module
+-----------------------------
+
+.. automodule:: feathr.lookup_feature
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.query\_feature\_list module
+----------------------------------
+
+.. automodule:: feathr.query_feature_list
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.materialization\_settings module
+---------------------------------------
+
+.. automodule:: feathr.materialization_settings
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.settings module
+----------------------
+
+.. automodule:: feathr.settings
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.sink module
+------------------
+
+.. automodule:: feathr.sink
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+feathr.feathr\_configurations module
+------------------------------------
+
+.. automodule:: feathr.feathr_configurations
+    :members:
+    :undoc-members:
+    :show-inheritance:
 
 Module contents
 ---------------

--- a/feathr_project/docs/feathr.rst
+++ b/feathr_project/docs/feathr.rst
@@ -1,4 +1,4 @@
-feathr package
+Feathr APIs for End Users
 ==============
 
 feathr.client module

--- a/feathr_project/docs/feathr_dev.rst
+++ b/feathr_project/docs/feathr_dev.rst
@@ -1,4 +1,4 @@
-feathr package
+Feathr APIs for Internal Developers
 ==============
 
 feathr.constants module

--- a/feathr_project/docs/index.rst
+++ b/feathr_project/docs/index.rst
@@ -3,10 +3,18 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Feathr's documentation!
+Welcome to Feathr's Python API documentation!
 ==================================
+If you are an end user, read `Feathr User APIs`.
 
-Feathr User APIs
+If you are a Feathr internal developer, read `Feathr APIs for Internal Developers`
+
+If you have any suggestions for our API documentation, please help us improve it by
+creating_ a Github issue for us.
+
+.. _creating: https://github.com/linkedin/feathr/issues/new
+
+Feathr APIs for End Users
 ==================
 
 .. toctree::

--- a/feathr_project/feathr/_materialization_utils.py
+++ b/feathr_project/feathr/_materialization_utils.py
@@ -1,4 +1,4 @@
-from jinja2 import Template 
+from jinja2 import Template
 from feathr.materialization_settings import MaterializationSettings
 
 
@@ -12,7 +12,7 @@ def _to_materialization_config(settings: MaterializationSettings):
             resolution: DAILY
             output:[
                     {% for sink in settings.sinks %}
-                        {{sink.to_write_config()}}
+                        {{sink.to_feature_config()}}
                     {% endfor %}
                 ]
             }

--- a/feathr_project/feathr/anchor.py
+++ b/feathr_project/feathr/anchor.py
@@ -4,19 +4,22 @@ from feathr.source import Source
 from feathr.typed_key import DUMMY_KEY
 from jinja2 import Template
 from feathr.source import INPUT_CONTEXT
+from feathr.frameconfig import HoconConvertible
 
-# passthrough features do not need keys
-class FeatureAnchor:
+
+class FeatureAnchor(HoconConvertible):
     """
         A feature anchor defines a set of features on top of a data source, a.k.a. a set of features anchored to a source.
 
         The feature producer writes multiple anchors for a feature, exposing the same feature name for the feature
         consumer to reference it.
+
         Attributes:
-        name: Unique name of the anchor.
-        source: data source that the features are anchored to. Should be either of `INPUT_CONTEXT` or `feathr.source.Source`
-        features: list of features within this anchor.
-        registry_tags: A dict of (str, str) that you can pass to feature registry for better organization. For example, you can use {"deprecated": "true"} to indicate this anchor is deprecated, etc.
+            name: Unique name of the anchor.
+            source: data source that the features are anchored to. Should be either of `INPUT_CONTEXT` or `feathr.source.Source`
+            features: list of features defined within this anchor.
+            registry_tags: A dict of (str, str) that you can pass to feature registry for better organization.
+                           For example, you can use {"deprecated": "true"} to indicate this anchor is deprecated, etc.
     """
     def __init__(self,
                 name: str,

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -134,7 +134,7 @@ class FeathrClient(object):
             self._FEATHR_JOB_JAR_PATH = \
                 envutils.get_environment_variable_with_default(
                     'spark_config', 'azure_synapse', 'feathr_runtime_location')
-            
+
             if self.credential is None:
                 self.credential = DefaultAzureCredential(exclude_interactive_browser_credential=False)
 
@@ -209,9 +209,10 @@ class FeathrClient(object):
                 raise RuntimeError("Please call FeathrClient.build_features() first in order to register features")
         else:
             self.registry.register_features(self.local_workspace_dir, from_context=from_context)
-    
+
     def build_features(self, anchor_list: List[FeatureAnchor] = [], derived_feature_list: List[DerivedFeature] = []):
-        """Registers features based on the current workspace
+        """Build features based on the current workspace. all actions that triggers a spark job will be based on the
+        result of this action.
         """
         # Run necessary validations
         # anchor name and source name should be unique

--- a/feathr_project/feathr/dtype.py
+++ b/feathr_project/feathr/dtype.py
@@ -1,12 +1,18 @@
 import enum
-from typing import Type, Union, List
-from abc import ABC, abstractmethod
-
-from jinja2 import Template
+from feathr.frameconfig import HoconConvertible
 
 class ValueType(enum.Enum):
-    """
-    Basic value type. Used as feature key type.
+    """Data type to describe feature keys or observation keys.
+
+    Attributes:
+        UNSPECIFIED: key data type is unspecified.
+        BOOL: key data type is boolean, either true or false
+        INT32: key data type is 32-bit integer, for example, an invoice id, 93231.
+        INT64: key data type is 64-bit integer, for example, an invoice id, 93231.
+        FLOAT: key data type is float, for example, 123.4f.
+        DOUBLE: key data type is double, for example, 123.4d.
+        STRING: key data type is string, for example, a user name, 'user_joe'
+        BYTES: key data type is bytes.
     """
     UNSPECIFIED = 0
     BOOL = 1
@@ -18,13 +24,13 @@ class ValueType(enum.Enum):
     BYTES = 7
 
 
-class FeatureType(ABC):
+class FeatureType(HoconConvertible):
     """Base class for all feature types"""
-    @abstractmethod
-    def to_feature_config(self) -> str:
-        pass
+    pass
 
 class BooleanFeatureType(FeatureType):
+    """Boolean feature value, either true or false.
+    """
     def to_feature_config(self) -> str:
         return """
            type: {
@@ -36,6 +42,8 @@ class BooleanFeatureType(FeatureType):
         """
 
 class Int32FeatureType(FeatureType):
+    """32-bit integer feature value, for example, 123, 98765.
+    """
     def to_feature_config(self) -> str:
         return """
             type: {
@@ -47,6 +55,8 @@ class Int32FeatureType(FeatureType):
         """
 
 class Int64FeatureType(FeatureType):
+    """64-bit integer(a.k.a. Long in some system) feature value, for example, 123, 98765 but stored in 64-bit integer.
+    """
     def to_feature_config(self) -> str:
         return """
             type: {
@@ -58,6 +68,8 @@ class Int64FeatureType(FeatureType):
         """
 
 class FloatFeatureType(FeatureType):
+    """Float feature value, for example, 1.3f, 2.4f.
+    """
     def to_feature_config(self) -> str:
         return """
             type: {
@@ -69,6 +81,8 @@ class FloatFeatureType(FeatureType):
         """
 
 class DoubleFeatureType(FeatureType):
+    """Double feature value, for example, 1.3d, 2.4d. Double has better precision than float.
+    """
     def to_feature_config(self) -> str:
         return """
             type: {
@@ -80,6 +94,8 @@ class DoubleFeatureType(FeatureType):
         """
 
 class StringFeatureType(FeatureType):
+    """String feature value, for example, 'apple', 'orange'.
+    """
     def to_feature_config(self) -> str:
         return """
             type: {
@@ -91,6 +107,8 @@ class StringFeatureType(FeatureType):
         """
 
 class BytesFeatureType(FeatureType):
+    """Bytes feature value.
+    """
     def to_feature_config(self) -> str:
         return """
             type: {
@@ -102,6 +120,8 @@ class BytesFeatureType(FeatureType):
         """
 
 class FloatVectorFeatureType(FeatureType):
+    """Float vector feature value, for example, [1,3f, 2.4f, 3.9f]
+    """
     def to_feature_config(self) -> str:
         return """
            type: {
@@ -114,6 +134,8 @@ class FloatVectorFeatureType(FeatureType):
 
 
 class Int32VectorFeatureType(FeatureType):
+    """32-bit integer vector feature value, for example, [1, 3, 9]
+    """
     def to_feature_config(self) -> str:
         return """
            type: {
@@ -126,6 +148,8 @@ class Int32VectorFeatureType(FeatureType):
 
 
 class Int64VectorFeatureType(FeatureType):
+    """64-bit integer vector feature value, for example, [1, 3, 9]
+    """
     def to_feature_config(self) -> str:
         return """
            type: {
@@ -138,6 +162,8 @@ class Int64VectorFeatureType(FeatureType):
 
 
 class DoubleVectorFeatureType(FeatureType):
+    """Double vector feature value, for example, [1.3d, 3.3d, 9.3d]
+    """
     def to_feature_config(self) -> str:
         return """
            type: {
@@ -147,6 +173,8 @@ class DoubleVectorFeatureType(FeatureType):
                 valType: DOUBLE
             }
         """
+
+
 # tensor dimension/axis
 class Dimension:
     def __init__(self, shape: int, dType: ValueType = ValueType.INT32):

--- a/feathr_project/feathr/feature.py
+++ b/feathr_project/feathr/feature.py
@@ -7,11 +7,12 @@ from jinja2 import Template
 from feathr.dtype import FeatureType
 from feathr.transformation import ExpressionTransformation, Transformation, WindowAggTransformation
 from feathr.typed_key import DUMMY_KEY, TypedKey
+from feathr.frameconfig import HoconConvertible
 
-
-class FeatureBase(ABC):
+class FeatureBase(HoconConvertible):
     """The base class for features
     It has a feature name, feature type, and a convenient transformation used to produce its feature value.
+
     Attributes:
         name: Unique name of the feature. Only alphabet, numbers, and '_' are allowed in the name.
                 It can not start with numbers. Note that '.' is NOT ALLOWED!
@@ -74,6 +75,7 @@ class FeatureBase(ABC):
 class Feature(FeatureBase):
     """A feature is an individual measurable property or characteristic of an entity.
     It has a feature name, feature type, and a convenient row transformation used to produce its feature value.
+
     Attributes:
         name: Unique name of the feature. Only alphabet, numbers, and '_' are allowed in the name.
                 It can not start with numbers. Note that '.' is NOT ALLOWED!

--- a/feathr_project/feathr/feature_derivations.py
+++ b/feathr_project/feathr/feature_derivations.py
@@ -10,6 +10,7 @@ from feathr.typed_key import DUMMY_KEY, TypedKey
 
 class DerivedFeature(FeatureBase):
     """A derived feature is a feature defined on top of other features, rather than external data source.
+
     Attributes:
         name: derived feature name
         feature_type: type of derived feature

--- a/feathr_project/feathr/frameconfig.py
+++ b/feathr_project/feathr/frameconfig.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+
+class HoconConvertible(ABC):
+    """Represent classes that can convert into Frame HOCON config.
+    """
+    @abstractmethod
+    def to_feature_config(self) -> str:
+        """Convert the feature anchor definition into internal HOCON format. (For internal use ony)"""
+        pass

--- a/feathr_project/feathr/lookup_feature.py
+++ b/feathr_project/feathr/lookup_feature.py
@@ -16,6 +16,7 @@ class LookupFeature(FeatureBase):
         base feature is user_purchased_item_ids. For a given user_id, it returns the item ids purchased by the user.
         expansion feature is item_price. For a given item id, it returns the item price.
         aggregation function is average of the item prices.
+
     Attributes:
         name: Derived feature name
         feature_type: Type of derived feature
@@ -23,8 +24,8 @@ class LookupFeature(FeatureBase):
         base_feature: The feature value of this feature will be used as key to lookup from the expansion feature
         expansion_feature: The feature to be looked up
         aggregation: Specify the aggregation for the feature values lookup from the expansion feature, in the
-                     case of the base feature value needed to be converted into multiple lookup keys, 
-                     e.g. feature value is an array and each value in the array is used once as a lookup key.   
+                     case of the base feature value needed to be converted into multiple lookup keys,
+                     e.g. feature value is an array and each value in the array is used once as a lookup key.
     """
 
     def __init__(self,

--- a/feathr_project/feathr/materialization_settings.py
+++ b/feathr_project/feathr/materialization_settings.py
@@ -6,6 +6,7 @@ import math
 
 class BackfillTime:
     """Time range to materialize/backfill feature data.
+
     Attributes:
         start: start time of the backfill, inclusive.
         end: end time of the backfill, inclusive.
@@ -18,7 +19,8 @@ class BackfillTime:
 
 
 class MaterializationSettings:
-    """
+    """Settings about materialization features.
+
     Attributes:
         name: The materialization job name
         sinks: sinks where the materialized features should be written to

--- a/feathr_project/feathr/query_feature_list.py
+++ b/feathr_project/feathr/query_feature_list.py
@@ -7,6 +7,7 @@ from feathr.typed_key import TypedKey
 
 class FeatureQuery:
     """A FeatureQuery contains a list of features
+
     Attributes:
         feature_list: a list of feature names
         key: key of `feature_list`, all features must share the same key

--- a/feathr_project/feathr/settings.py
+++ b/feathr_project/feathr/settings.py
@@ -1,18 +1,18 @@
 from typing import Optional
 from jinja2 import Template
 from loguru import logger
+from feathr.frameconfig import HoconConvertible
 
-
-class ObservationSettings:
+class ObservationSettings(HoconConvertible):
     """Time settings of the observation data. Used in feature join.
+
     Attributes:
         observation_path: path to the observation dataset, i.e. input dataset to get with features
-        event_timestamp_column (Optional[str]): The timestamp field of your record. As sliding window aggregation feature assume each record in the source data should have a timestamp column. 
-        timestamp_format (Optional[str], optional): The format of the timestamp field. Defaults to "epoch". Possible values are: 
-        - `epoch` (seconds since epoch), for example `1647737463`
-        - `epoch_millis` (milliseconds since epoch), for example `1647737517761`
-        - Any date formats supported by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html). 
-            
+        event_timestamp_column (Optional[str]): The timestamp field of your record. As sliding window aggregation feature assume each record in the source data should have a timestamp column.
+        timestamp_format (Optional[str], optional): The format of the timestamp field. Defaults to "epoch". Possible values are:
+            - `epoch` (seconds since epoch), for example `1647737463`
+            - `epoch_millis` (milliseconds since epoch), for example `1647737517761`
+            - Any date formats supported by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html).
     """
     def __init__(self,
                  observation_path: str,

--- a/feathr_project/feathr/sink.py
+++ b/feathr_project/feathr/sink.py
@@ -1,16 +1,17 @@
-from abc import ABC, abstractmethod
 from typing import List, Optional
 from jinja2 import Template
+from feathr.frameconfig import HoconConvertible
 
 
-class Sink(ABC):
-    @abstractmethod
-    def to_write_config(self) -> str:
-        pass
+class Sink(HoconConvertible):
+    """A data sink.
+    """
+    pass
 
 
 class RedisSink(Sink):
     """Redis-based sink use to store online feature data, can be used in batch job or streaming job.
+
     Attributes:
         table_name: output table name
         streaming: whether it is used in streaming mode
@@ -21,7 +22,7 @@ class RedisSink(Sink):
         self.streaming = streaming
         self.streamingTimeoutMs = streamingTimeoutMs
 
-    def to_write_config(self) -> str:
+    def to_feature_config(self) -> str:
         """Produce the config used in feature materialization"""
         tm = Template("""  
             {

--- a/feathr_project/feathr/source.py
+++ b/feathr_project/feathr/source.py
@@ -1,6 +1,7 @@
 
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, List, Optional
+from feathr.frameconfig import HoconConvertible
 
 from jinja2 import Template
 from loguru import logger
@@ -12,11 +13,12 @@ class SourceSchema(ABC):
 
 
 class AvroJsonSchema(SourceSchema):
-    """Avro schema written in Json"""
+    """Avro schema written in Json string form."""
     def __init__(self, schemaStr:str):
         self.schemaStr = schemaStr
 
     def to_feature_config(self):
+        """Convert the feature anchor definition into internal HOCON format."""
         tm = Template("""
         schema: {
             type = "avro"
@@ -28,13 +30,15 @@ class AvroJsonSchema(SourceSchema):
         return msg
 
 
-class Source:
-    """External data source for feature. Typically a 'table'.
-     Attributes:
-         name: name of the source
-         event_timestamp_column: column name of the event timestamp
-         timestamp_format: the format of the event_timestamp_column, e.g. yyyy/MM/DD.
-         registry_tags: A dict of (str, str) that you can pass to feature registry for better organization. For example, you can use {"deprecated": "true"} to indicate this source is deprecated, etc.
+class Source(HoconConvertible):
+    """External data source for feature. Typically a data 'table'.
+
+    Attributes:
+         name: name of the source. It's used to differentiate from other sources.
+         event_timestamp_column: column name or field name of the event timestamp
+         timestamp_format: the format of the event_timestamp_column, e.g. yyyy/MM/DD, or EPOCH
+         registry_tags: A dict of (str, str) that you can pass to feature registry for better organization.
+                        For example, you can use {"deprecated": "true"} to indicate this source is deprecated, etc.
     """
     def __init__(self,
                  name: str,
@@ -55,19 +59,20 @@ class Source:
         """A source can be identified with the name"""
         return hash(self.name)
 
-    def to_write_config(self) -> str:
-        pass
-
     def __str__(self):
         return self.to_feature_config()
 
 
 class InputContext(Source):
-    """A type of 'passthrough' source, a.k.a. request feature source.
+    """'Passthrough' source, a.k.a. request feature source. Feature source data is from the observation data itself.
+    For example, you have an observation data table t1 and another feature data table t2. Some of your feature data
+    can be transformed from the observation data table t1 itself, like geo location, then you can define that feature
+    on top of the InputContext.
     """
-    SOURCE_NAME = "PASSTHROUGH"
+    __SOURCE_NAME = "PASSTHROUGH"
+
     def __init__(self) -> None:
-        super().__init__(self.SOURCE_NAME, None, None)
+        super().__init__(self.__SOURCE_NAME, None, None)
 
     def to_feature_config(self) -> str:
         return "source: " + self.name
@@ -76,20 +81,20 @@ class InputContext(Source):
 class HdfsSource(Source):
     """A data source(table) stored on HDFS-like file system. Data can be fetch through a POSIX style path.
 
-        Args:
-            name (str): name of the source
-            path (str): The location of the source data.
-            preprocessing (Optional[Callable]): A preprocessing python function that transforms the source data for further feature transformation.
-            event_timestamp_column (Optional[str]): The timestamp field of your record. As sliding window aggregation feature assume each record in the source data should have a timestamp column.
-            timestamp_format (Optional[str], optional): The format of the timestamp field. Defaults to "epoch". Possible values are:
-            - `epoch` (seconds since epoch), for example `1647737463`
-            - `epoch_millis` (milliseconds since epoch), for example `1647737517761`
-            - Any date formats supported by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html). 
-            registry_tags: A dict of (str, str) that you can pass to feature registry for better organization. For example, you can use {"deprecated": "true"} to indicate this source is deprecated, etc.
-        """
+    Attributes:
+        name (str): name of the source
+        path (str): The location of the source data.
+        preprocessing (Optional[Callable]): A preprocessing python function that transforms the source data for further feature transformation.
+        event_timestamp_column (Optional[str]): The timestamp field of your record. As sliding window aggregation feature assume each record in the source data should have a timestamp column.
+        timestamp_format (Optional[str], optional): The format of the timestamp field. Defaults to "epoch". Possible values are:
+                                                    - `epoch` (seconds since epoch), for example `1647737463`
+                                                    - `epoch_millis` (milliseconds since epoch), for example `1647737517761`
+                                                    - Any date formats supported by [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html).
+        registry_tags: A dict of (str, str) that you can pass to feature registry for better organization. For example, you can use {"deprecated": "true"} to indicate this source is deprecated, etc.
+    """
     def __init__(self, name: str, path: str, preprocessing: Optional[Callable] = None, event_timestamp_column: Optional[str]= None, timestamp_format: Optional[str] = "epoch", registry_tags: Optional[Dict[str, str]] = None) -> None:
         super().__init__(name, event_timestamp_column, timestamp_format, registry_tags=registry_tags)
-        self.path = path    
+        self.path = path
         self.preprocessing = preprocessing
         if path.startswith("http"):
             logger.warning("Your input path {} starts with http, which is not supported. Consider using paths starting with wasb[s]/abfs[s]/s3.", path)
@@ -116,6 +121,7 @@ class HdfsSource(Source):
 
 class KafkaConfig:
     """Kafka config for a streaming source
+
     Attributes:
         brokers: broker/server address
         topics: Kafka topics

--- a/feathr_project/feathr/transformation.py
+++ b/feathr_project/feathr/transformation.py
@@ -2,9 +2,9 @@ import enum
 from typing import Type, Union, List, Optional
 from abc import ABC, abstractmethod
 from jinja2 import Template
+from feathr.frameconfig import HoconConvertible
 
-
-class Transformation(ABC):
+class Transformation(HoconConvertible):
     """Base class for all transformations that produce feature values."""
     @abstractmethod
     def to_feature_config(self, with_def_field_name: Optional[bool] = True) -> str:
@@ -18,6 +18,7 @@ class RowTransformation(Transformation):
 
 class ExpressionTransformation(RowTransformation):
     """A row-level transformations that is defined with the Feathr expression language.
+
     Attributes:
         expr: expression that transforms the raw value into a new value, e.g. amount * 10.
     """


### PR DESCRIPTION
Refactoring python documentation.
1. Reorder the docs in RST file
2. Reformat some broken python docstring
3. Fix some documentation.

![image](https://user-images.githubusercontent.com/5482153/166131122-037350d4-be8b-4480-99c3-8dca2897d88d.png)
