### PR TITLE
Fix ui workflow deployment fails with error: The content server has unexpectedly rejected the request with: LengthRequired

### DIFF
--- a/.github/workflows/feathr-web-ui.yml
+++ b/.github/workflows/feathr-web-ui.yml
@@ -29,7 +29,7 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/ui" # App source code path
-          api_location: "api" # Api source code path - optional
+          api_location: "" # Api source code path - optional
           output_location: "build" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 


### PR DESCRIPTION
The default Azure web app deploy workflow is configured with an API location, which caused the GitHub action to treat entire repo as an Azure Function app and try to deploy it,  and causes ui workflow deployment failure.

This PR unsets the api location in workflow yml file to fix it.