### PR TITLE
Improve Feature Registry Usability

### DIFF
--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -3,7 +3,6 @@ import importlib
 import inspect
 import itertools
 import os
-from re import X
 import sys
 import ast
 import types
@@ -932,7 +931,18 @@ derivations: {
 
 
     def _correct_function_identation(self, user_func: str) -> str:
-        """The function read from registry might have the wrong identation. We need to correct those identations.
+        """
+        The function read from registry might have the wrong identation. We need to correct those identations.
+        More specifically, we are using the inspect module to copy the function body for UDF for further submission. In that case, there will be situations like this:
+
+        def feathr_udf1(df)
+            return df
+
+                def feathr_udf2(df)
+                    return df
+
+        For example, in Feathr test cases, there are similar patterns for `feathr_udf2`, since it's defined in another function body (the registry_test_setup method).
+        This is not an ideal way of dealing with that, but we'll keep it here until we figure out a better way.
         """
         if user_func is None:
             return None

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -878,7 +878,11 @@ derivations: {
         derived_feature_list = []
         for derived_feature_entity_id in derived_feature_ids:
             # this will be used to generate DerivedFeature instance
-            key_from_entity=derived_feature_entity_id["attributes"]["tags"]
+            derived_feature_key_list = []
+
+                
+            for key in derived_feature_entity_id["attributes"]["key"]:
+                derived_feature_key_list.append(TypedKey(key_column=key["key_column"], key_column_type=key["key_column_type"], full_name=key["full_name"], description=key["description"], key_column_alias=key["key_column_alias"]))
             
             # for feature anchor (GROUP), input features are splitted into input anchor features & input derived features
             anchor_feature_guid = [e["guid"] for e in derived_feature_entity_id["attributes"]["input_anchor_features"]]
@@ -894,7 +898,7 @@ derivations: {
             derived_feature_list.append(DerivedFeature(name=derived_feature_entity_id["attributes"]["name"],
                                 feature_type=self._get_feature_type_from_hocon(derived_feature_entity_id["attributes"]["type"]),
                                 transform=self._get_transformation_from_dict(derived_feature_entity_id["attributes"]['transformation']),
-                                key=key_from_entity,
+                                key=derived_feature_key_list,
                                 input_features= all_input_features,
                                 registry_tags=derived_feature_entity_id["attributes"]["tags"]))                    
         anchor_result = self.purview_client.get_entity(guid=anchor_guid)["entities"]

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -32,7 +32,7 @@ from feathr._file_utils import write_to_file
 from feathr.anchor import FeatureAnchor
 from feathr.constants import *
 from feathr.dtype import *
-from feathr.feature import Feature, FeatureType
+from feathr.feature import Feature, FeatureBase, FeatureType
 from feathr.feature_derivations import DerivedFeature
 from feathr.repo_definitions import RepoDefinitions
 from feathr.source import HdfsSource, InputContext, Source
@@ -949,7 +949,6 @@ derivations: {
     def _get_source_by_guid(self, guid) -> Source:
         # TODO: currently return HDFS source by default. For JDBC source, it's currently implemented using HDFS Source so we should split in the future
         source_entity = self.purview_client.get_entity(guid=guid)["entities"][0]
-        print(source_entity["attributes"]["preprocessing"],)
 
         # if source_entity["attributes"]["path"] is INPUT_CONTEXT, it will also be assigned to this returned object
         return HdfsSource(name=source_entity["attributes"]["name"],
@@ -963,6 +962,14 @@ derivations: {
 
 
     def _get_feature_type_from_hocon(self, input_str: str) -> FeatureType:
+        """Get Feature types from a HOCON config, given that we stored the feature type in a plain string.
+
+        Args:
+            input_str (str): the input string for the stored HOCON config
+
+        Returns:
+            FeatureType: feature type that can be used by Python
+        """
         conf = ConfigFactory.parse_string(input_str)
         valType = conf.get_string('type.valType')
         dimensionType = conf.get_string('type.dimensionType')

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -840,7 +840,7 @@ derivations: {
             guid=guid_list)["entities"]
         return entity_res
         
-    def get_features_from_registry(self, project_name: str) -> (List[FeatureAnchor], List[DerivedFeature]):
+    def get_features_from_registry(self, project_name: str) -> Tuple(List[FeatureAnchor], List[DerivedFeature]):
         """Sync Features from registry to local workspace, given a project_name, will write project's features from registry to to user's local workspace]
         If the project is big, the return result could be huge.
         Args:

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -116,8 +116,6 @@ class _FeatureRegistry():
                                   cardinality=Cardinality.SINGLE),
                 AtlasAttributeDef(name="tags", typeName="map<string,string>",
                                   cardinality=Cardinality.SINGLE),
-                AtlasAttributeDef(name="feature_config", typeName="string",
-                                  cardinality=Cardinality.SINGLE)
             ],
             superTypes=["DataSet"],
         )
@@ -138,8 +136,6 @@ class _FeatureRegistry():
                                   cardinality=Cardinality.SINGLE),
                 AtlasAttributeDef(name="tags", typeName="map<string,string>",
                                   cardinality=Cardinality.SINGLE),
-                AtlasAttributeDef(name="feature_config", typeName="string",
-                                  cardinality=Cardinality.SINGLE)
             ],
             superTypes=["DataSet"],
         )
@@ -202,7 +198,6 @@ class _FeatureRegistry():
                     "key": key_list,
                     "transformation": transform_dict,
                     "tags": anchor_feature.registry_tags,
-                    "feature_config": anchor_feature.to_feature_config()
                 },
                 typeName=TYPEDEF_ANCHOR_FEATURE,
                 guid=self.guid.get_guid(),
@@ -380,7 +375,6 @@ class _FeatureRegistry():
                     "input_derived_features": [f.to_json(minimum=True) for f in input_feature_entity_list if f.typeName==TYPEDEF_DERIVED_FEATURE],
                     "transformation": transform_dict,
                     "tags": derived_feature.registry_tags,
-                    "feature_config": derived_feature.to_feature_config()
 
                 },
                 typeName=TYPEDEF_DERIVED_FEATURE,
@@ -681,7 +675,7 @@ derivations: {
         """
         Delete all the feathr related entities and type definitions in feathr registry. For internal use only
         """
-        self._delete_all_feathr_entitties()
+        self._delete_all_feathr_entities()
         self._delete_all_feathr_types()
 
 
@@ -706,7 +700,7 @@ derivations: {
 
         logger.info("Deleted all the Feathr related definitions.")
 
-    def _delete_all_feathr_entitties(self):
+    def _delete_all_feathr_entities(self):
         """
         Delete all the corresonding entity for feathr registry. For internal use only
 
@@ -824,7 +818,8 @@ derivations: {
                 raise RuntimeError(
                     f'only SOURCE, DERIVED_FEATURE, ANCHOR, ANCHOR_FEATURE, FEATHR_PROJECT are supported when listing the registered entities, {entity_type} is not one of them.')
 
-        # the search grammar is less documented in Atlas/Purview
+        # the search grammar is less documented in Atlas/Purview. 
+        # Here's the query grammar: https://atlas.apache.org/2.0.0/Search-Advanced.html
         search_string = "".join(
             [f" or entityType:{e}" for e in entity_type_list])
         # remvoe the first additional " or "

--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -117,6 +117,8 @@ class _FeatureRegistry():
                                   cardinality=Cardinality.SINGLE),
                 AtlasAttributeDef(name="tags", typeName="map<string,string>",
                                   cardinality=Cardinality.SINGLE),
+                AtlasAttributeDef(name="feature_config", typeName="string",
+                                  cardinality=Cardinality.SINGLE)
             ],
             superTypes=["DataSet"],
         )
@@ -137,6 +139,8 @@ class _FeatureRegistry():
                                   cardinality=Cardinality.SINGLE),
                 AtlasAttributeDef(name="tags", typeName="map<string,string>",
                                   cardinality=Cardinality.SINGLE),
+                AtlasAttributeDef(name="feature_config", typeName="string",
+                                  cardinality=Cardinality.SINGLE)
             ],
             superTypes=["DataSet"],
         )
@@ -199,6 +203,7 @@ class _FeatureRegistry():
                     "key": key_list,
                     "transformation": transform_dict,
                     "tags": anchor_feature.registry_tags,
+                    "feature_config": anchor_feature.to_feature_config()
                 },
                 typeName=TYPEDEF_ANCHOR_FEATURE,
                 guid=self.guid.get_guid(),
@@ -375,7 +380,9 @@ class _FeatureRegistry():
                     "input_anchor_features": [f.to_json(minimum=True) for f in input_feature_entity_list if f.typeName==TYPEDEF_ANCHOR_FEATURE],
                     "input_derived_features": [f.to_json(minimum=True) for f in input_feature_entity_list if f.typeName==TYPEDEF_DERIVED_FEATURE],
                     "transformation": transform_dict,
-                    "tags": derived_feature.registry_tags
+                    "tags": derived_feature.registry_tags,
+                    "feature_config": derived_feature.to_feature_config()
+
                 },
                 typeName=TYPEDEF_DERIVED_FEATURE,
                 guid=self.guid.get_guid(),
@@ -939,7 +946,8 @@ derivations: {
         # TODO: currently return HDFS source by default. For JDBC source, it's currently implemented using HDFS Source so we should split in the future
         source_entity = self.purview_client.get_entity(guid=guid)["entities"][0]
         print(source_entity["attributes"]["preprocessing"],)
-        
+
+        # if source_entity["attributes"]["path"] is INPUT_CONTEXT, it will also be assigned to this returned object
         return HdfsSource(name=source_entity["attributes"]["name"],
                 event_timestamp_column=source_entity["attributes"]["event_timestamp_column"],
                 timestamp_format=source_entity["attributes"]["timestamp_format"],
@@ -989,7 +997,7 @@ derivations: {
             # it's ExpressionTransformation
             return ExpressionTransformation(input['transform_expr'])
         elif 'def_expr' in input:
-            return WindowAggTransformation(agg_expr=input['def_expr'], agg_func=input['agg_func'], window=input['agg_func'], group_by=input['agg_func'], filter=input['agg_func'], limit=input['agg_func'])
+            return WindowAggTransformation(agg_expr=input['def_expr'], agg_func=input['agg_func'], window=input['window'], group_by=input['group_by'], filter=input['filter'], limit=input['limit'])
         else:
             # no transformation function observed
             return None

--- a/feathr_project/feathr/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/_preprocessing_pyudf_manager.py
@@ -88,17 +88,12 @@ class _PreprocessingPyudfManager(object):
     @staticmethod
     def persist_pyspark_udf_to_file(user_func, local_workspace_dir):
         """persist the pyspark UDF to a file in `local_workspace_dir` for later usage. 
-        The user_func could be either a string that represents a function body, or a callable object.
+        The user_func could be either a string that represents a function body, or a callable object. 
+        The reason being - if we are defining a regular Python function, it will be a callable object; 
+        however if we reterive features from registry, the current implementation is to use plain strings to store the function body. In that case, the user_fuc will be string.
         """
         if isinstance(user_func, str):
-            # if user_func is a string, turn it into a list of strings so that it can be used below
-            temp_udf_source_code = user_func.split('\n')
-            # assuming the first line is the function name
-            leading_space_num = len(temp_udf_source_code[0]) - len(temp_udf_source_code[0].lstrip())
-            # strip the lines to make sure the function has the correct indentation
-            udf_source_code_striped = [line[leading_space_num:] for line in temp_udf_source_code]
-            # append '\n' back since it was deleted due to the previous split
-            udf_source_code = [line+'\n' for line in udf_source_code_striped]
+            udf_source_code = [user_func]
         else:
             udf_source_code = inspect.getsourcelines(user_func)[0]
         lines = []

--- a/feathr_project/feathr/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/_preprocessing_pyudf_manager.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 import pickle
 from jinja2 import Template
 from feathr.source import HdfsSource
+import ast
 
 # Some metadata that are only needed by Feathr
 FEATHR_PYSPARK_METADATA = 'generated_feathr_pyspark_metadata'
@@ -33,6 +34,9 @@ class _PreprocessingPyudfManager(object):
         # features that have preprocessing defined. This is used to figure out if we need to kick off Pyspark
         # preprocessing for requested features.
         features_with_preprocessing = []
+        client_udf_repo_path = os.path.join(local_workspace_dir, FEATHR_CLIENT_UDF_FILE_NAME)
+        # delete the file if it already exists to avoid caching previous results
+        os.remove(client_udf_repo_path) if os.path.exists(client_udf_repo_path) else None
         for anchor in anchor_list:
             # only support batch source preprocessing for now.
             if not isinstance(anchor.source, HdfsSource):
@@ -44,7 +48,11 @@ class _PreprocessingPyudfManager(object):
                 features_with_preprocessing = features_with_preprocessing + feature_names
                 feature_names.sort()
                 string_feature_list = ','.join(feature_names)
-                feature_names_to_func_mapping[string_feature_list] = anchor.source.preprocessing
+                if isinstance(anchor.source.preprocessing, str):
+                    feature_names_to_func_mapping[string_feature_list] = _PreprocessingPyudfManager._parse_function_str_for_name(anchor.source.preprocessing)
+                else:
+                    # it's a callable function
+                    feature_names_to_func_mapping[string_feature_list] = anchor.source.preprocessing.__name__ 
 
         if not features_with_preprocessing:
             return
@@ -59,12 +67,38 @@ class _PreprocessingPyudfManager(object):
             pickle.dump(features_with_preprocessing, file)
 
     @staticmethod
+    def _parse_function_str_for_name(source: str) -> str:
+        """
+        Use AST to parse the functions and get the name out.
+        """
+        if source is None:
+            return None
+        tree = ast.parse(source)
+        if len(tree.body) != 1 or not isinstance(tree.body[0], ast.FunctionDef):
+            raise ValueError('provided code fragment is not a single function')
+        code = compile(source=tree, filename='custom.py',mode= 'exec')
+        # https://docs.python.org/3/library/inspect.html see the inspect module for more details
+        # tuple of names other than arguments and function locals. Assume there will be only one function, so will return the first as the name
+        for ele in code.co_consts:
+            # find the first object, that is the str, this will be the name of the function
+            if isinstance(ele, str):
+                return ele
+
+
+    @staticmethod
     def persist_pyspark_udf_to_file(user_func, local_workspace_dir):
         """persist the pyspark UDF to a file in `local_workspace_dir` for later usage. 
         The user_func could be either a string that represents a function body, or a callable object.
         """
         if isinstance(user_func, str):
-            udf_source_code = user_func
+            # if user_func is a string, turn it into a list of strings so that it can be used below
+            temp_udf_source_code = user_func.split('\n')
+            # assuming the first line is the function name
+            leading_space_num = len(temp_udf_source_code[0]) - len(temp_udf_source_code[0].lstrip())
+            # strip the lines to make sure the function has the correct indentation
+            udf_source_code_striped = [line[leading_space_num:] for line in temp_udf_source_code]
+            # append '\n' back since it was deleted due to the previous split
+            udf_source_code = [line+'\n' for line in udf_source_code_striped]
         else:
             udf_source_code = inspect.getsourcelines(user_func)[0]
         lines = []
@@ -98,7 +132,7 @@ class _PreprocessingPyudfManager(object):
         tm = Template("""
 feature_names_funcs = {
 {% for key, value in func_maps.items() %}
-    "{{key}}" : {{value.__name__}},
+    "{{key}}" : {{value}},
 {% endfor %}
 }
         """)

--- a/feathr_project/feathr/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/_preprocessing_pyudf_manager.py
@@ -60,7 +60,13 @@ class _PreprocessingPyudfManager(object):
 
     @staticmethod
     def persist_pyspark_udf_to_file(user_func, local_workspace_dir):
-        udf_source_code = inspect.getsourcelines(user_func)[0]
+        """persist the pyspark UDF to a file in `local_workspace_dir` for later usage. 
+        The user_func could be either a string that represents a function body, or a callable object.
+        """
+        if isinstance(user_func, str):
+            udf_source_code = user_func
+        else:
+            udf_source_code = inspect.getsourcelines(user_func)[0]
         lines = []
         # Some basic imports will be provided
         lines = lines + PROVIDED_IMPORTS

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -5,6 +5,7 @@ import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Union
+from feathr.feature import FeatureBase
 
 import redis
 from azure.identity import DefaultAzureCredential
@@ -700,10 +701,17 @@ class FeathrClient(object):
             """.format(sasl=sasl)
         return config_str
 
-    def get_features_from_registry(self, project_name: str):
+    def get_features_from_registry(self, project_name: str) -> Dict[str, FeatureBase]:
         """
         Get feature from registry by project name. The features got from registry are automatically built.
         """
         registry_anchor_list, registry_derived_feature_list = self.registry.get_features_from_registry(project_name)
         self.build_features(registry_anchor_list, registry_derived_feature_list)
-        return registry_anchor_list, registry_derived_feature_list
+        feature_dict = {}
+        # add those features into a dict for easier lookup
+        for anchor in registry_anchor_list:
+            for feature in anchor.features:
+                feature_dict[feature.name] = feature
+        for feature in registry_derived_feature_list:
+                feature_dict[feature.name] = feature
+        return feature_dict

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -702,6 +702,7 @@ class FeathrClient(object):
 
     def get_features_from_registry(self,project_name):
         """
-        Get feature from registry by project name
+        Get feature from registry by project name. The features got from registry are automatically built.
         """
-        return self.registry.get_features_from_registry(project_name)
+        registry_anchor_list, registry_derived_feature_list = self.registry.get_features_from_registry(project_name)
+        self.build_features(registry_anchor_list, registry_derived_feature_list)

--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -700,9 +700,10 @@ class FeathrClient(object):
             """.format(sasl=sasl)
         return config_str
 
-    def get_features_from_registry(self,project_name):
+    def get_features_from_registry(self, project_name: str):
         """
         Get feature from registry by project name. The features got from registry are automatically built.
         """
         registry_anchor_list, registry_derived_feature_list = self.registry.get_features_from_registry(project_name)
         self.build_features(registry_anchor_list, registry_derived_feature_list)
+        return registry_anchor_list, registry_derived_feature_list

--- a/feathr_project/feathrcli/data/feathr_user_workspace/features/request_features.py
+++ b/feathr_project/feathrcli/data/feathr_user_workspace/features/request_features.py
@@ -7,7 +7,7 @@ from feathr.source import INPUT_CONTEXT
 f_trip_distance = Feature(name="f_trip_distance", feature_type=FLOAT, transform="trip_distance")
 f_trip_time_duration = Feature(name="f_trip_time_duration",
             feature_type=INT32,
-            transform="time_duration(lpep_pickup_datetime, lpep_dropoff_datetime, 'minutes')")
+            transform="(to_unix_timestamp(lpep_dropoff_datetime) - to_unix_timestamp(lpep_pickup_datetime))/60")
 
 features = [
     f_trip_distance,

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -49,7 +49,7 @@ def test_feathr_register_features_e2e():
     client.get_features_from_registry(project_name)
 
     feature_query = FeatureQuery(
-        feature_list=["f_location_avg_fare", "f_trip_time_rounded", "f_is_long_trip_distance", "f_location_total_fare_cents"], 
+        feature_list=["f_location_avg_fare", "f_trip_time_rounded", "f_is_long_trip_distance"], 
         key=TypedKey(key_column="DOLocationID",key_column_type=ValueType.INT32))
     settings = ObservationSettings(
         observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04_with_index.csv",

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -39,6 +39,7 @@ def test_feathr_register_features_e2e():
     time.sleep(5)
     # in CI test, the project name is set by the CI pipeline so we read it here
     project_name = os.environ["PROJECT_CONFIG__PROJECT_NAME"]
+    print("project_name is", project_name)
     all_features = client.list_registered_features(project_name=project_name)
     assert 'f_is_long_trip_distance' in all_features # test regular ones
     assert 'f_trip_time_rounded' in all_features # make sure derived features are there

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -31,7 +31,6 @@ def test_feathr_register_features_e2e():
     assert 'f_trip_time_rounded_plus' in all_features # make sure derived features are there 
     assert 'f_trip_time_distance' in all_features # make sure derived features are there  
 
-    client = FeathrClient()
     # Sync workspace from registry, will get all conf files back
     features = client.get_features_from_registry(project_name)
     assert len(features)==2

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -38,9 +38,8 @@ def test_feathr_register_features_e2e():
     # Allow purview to process a bit
     time.sleep(5)
     # in CI test, the project name is set by the CI pipeline so we read it here
-    project_name = os.environ["PROJECT_CONFIG__PROJECT_NAME"]
-    print("project_name is", project_name)
-    all_features = client.list_registered_features(project_name=project_name)
+    print("project_name is", client.project_name, os.environ["project_config__project_name"])
+    all_features = client.list_registered_features(project_name=client.project_name)
     assert 'f_is_long_trip_distance' in all_features # test regular ones
     assert 'f_trip_time_rounded' in all_features # make sure derived features are there
     assert 'f_location_avg_fare' in all_features # make sure aggregated features are there
@@ -48,7 +47,7 @@ def test_feathr_register_features_e2e():
     assert 'f_trip_time_distance' in all_features # make sure derived features are there  
 
     # Sync workspace from registry, will get all conf files back
-    client.get_features_from_registry(project_name)
+    client.get_features_from_registry(client.project_name)
 
     feature_query = FeatureQuery(
         feature_list=["f_location_avg_fare", "f_trip_time_rounded", "f_is_long_trip_distance"], 

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -1,24 +1,38 @@
 import glob
 import os
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
-from feathr.anchor import FeatureAnchor
-from feathr.feature_derivations import DerivedFeature
-from numpy import equal
 
 import pytest
 from click.testing import CliRunner
-from feathr.client import FeathrClient
-from feathrcli.cli import init
+from feathr import (FeatureAnchor, FeatureQuery, ObservationSettings, TypedKey,
+                    ValueType)
 from feathr._feature_registry import _FeatureRegistry
+from feathr.client import FeathrClient
+from feathr.feature_derivations import DerivedFeature
+from feathrcli.cli import init
+from numpy import equal
+
 from test_fixture import basic_test_setup, registry_test_setup
 
 
 def test_feathr_register_features_e2e():
+    """
+    This test will register features, get all the registered features, then query a set of already registered features.
+    """
 
     test_workspace_dir = Path(
         __file__).parent.resolve() / "test_user_workspace"
-    client = registry_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
+    client: FeathrClient = registry_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
+    # set output folder based on different runtime
+    now = datetime.now()
+    if client.spark_runtime == 'databricks':
+        output_path = ''.join(['dbfs:/feathrazure_cijob','_', str(now.minute), '_', str(now.second), ".parquet"])
+    else:
+        output_path = ''.join(['abfss://feathrazuretest3fs@feathrazuretest3storage.dfs.core.windows.net/demo_data/output','_', str(now.minute), '_', str(now.second), ".parquet"])
+
+    
     client.register_features()
     # Allow purview to process a bit
     time.sleep(5)
@@ -32,35 +46,20 @@ def test_feathr_register_features_e2e():
     assert 'f_trip_time_distance' in all_features # make sure derived features are there  
 
     # Sync workspace from registry, will get all conf files back
-    features = client.get_features_from_registry(project_name)
-    assert len(features)==2
-    assert isinstance(features[0][0],FeatureAnchor)
-    assert isinstance(features[1][0],DerivedFeature)
-    assert len(features[0])==2
-    anchor1_features = [x.name for x in features[0][0].features]
-    assert len(anchor1_features)==2 and \
-        'f_location_avg_fare' in anchor1_features and \
-        'f_location_max_fare' in anchor1_features
+    client.get_features_from_registry(project_name)
 
-    anchor2_features = [x.name for x in features[0][1].features]
-    assert len(anchor2_features)==4 and \
-        'f_trip_distance' in anchor2_features and \
-        'f_trip_time_duration' in anchor2_features and \
-        'f_is_long_trip_distance' in anchor2_features and \
-        'f_day_of_week' in anchor2_features
+    feature_query = FeatureQuery(
+        feature_list=["f_location_avg_fare", "f_trip_time_rounded", "f_is_long_trip_distance", "f_location_total_fare_cents"], 
+        key=TypedKey(key_column="DOLocationID",key_column_type=ValueType.INT32))
+    settings = ObservationSettings(
+        observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04_with_index.csv",
+        event_timestamp_column="lpep_dropoff_datetime",
+        timestamp_format="yyyy-MM-dd HH:mm:ss")
+    client.get_offline_features(observation_settings=settings,
+                                feature_query=feature_query,
+                                output_path=output_path)
+    client.wait_job_to_finish(timeout_sec=500)
 
-    assert len(features[1])==3
-    derived1_inputs = [x.name for x in features[1][0].input_features]
-    assert len(derived1_inputs)==1 and 'f_trip_time_duration' in derived1_inputs
-
-    derived2_inputs = [x.name for x in features[1][1].input_features]
-    assert len(derived2_inputs)==2 and\
-        'f_trip_distance' in derived2_inputs and \
-        'f_trip_time_duration' in derived2_inputs
-    
-    derived3_inputs = [x.name for x in features[1][2].input_features]
-    assert len(derived3_inputs)==1 and\
-        'f_trip_time_duration' in derived3_inputs
 
     
 def test_get_feature_from_registry():

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -25,6 +25,7 @@ def test_feathr_register_features_e2e():
     test_workspace_dir = Path(
         __file__).parent.resolve() / "test_user_workspace"
     client: FeathrClient = registry_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
+    
     # set output folder based on different runtime
     now = datetime.now()
     if client.spark_runtime == 'databricks':

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -38,7 +38,6 @@ def test_feathr_register_features_e2e():
     # Allow purview to process a bit
     time.sleep(5)
     # in CI test, the project name is set by the CI pipeline so we read it here
-    print("project_name is", client.project_name, os.environ["project_config__project_name"])
     all_features = client.list_registered_features(project_name=client.project_name)
     assert 'f_is_long_trip_distance' in all_features # test regular ones
     assert 'f_trip_time_rounded' in all_features # make sure derived features are there

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -166,6 +166,7 @@ def registry_test_setup(config_path: str):
     os.environ["project_config__project_name"] =  ''.join(['feathr_ci_registry','_', str(now.minute), '_', str(now.second), '_', str(now.microsecond)]) 
 
     client = FeathrClient(config_path=config_path, project_registry_tag={"for_test_purpose":"true"})
+    print("project name after client initialization is", client.project_name)
 
     def add_new_dropoff_and_fare_amount_column(df: DataFrame):
         df = df.withColumn("new_lpep_dropoff_datetime", col("lpep_dropoff_datetime"))

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -166,7 +166,6 @@ def registry_test_setup(config_path: str):
     os.environ["project_config__project_name"] =  ''.join(['feathr_ci_registry','_', str(now.minute), '_', str(now.second), '_', str(now.microsecond)]) 
 
     client = FeathrClient(config_path=config_path, project_registry_tag={"for_test_purpose":"true"})
-    print("project name after client initialization is", client.project_name)
 
     def add_new_dropoff_and_fare_amount_column(df: DataFrame):
         df = df.withColumn("new_lpep_dropoff_datetime", col("lpep_dropoff_datetime"))

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -30,7 +30,7 @@ def basic_test_setup(config_path: str):
                               feature_type=FLOAT, transform="trip_distance")
     f_trip_time_duration = Feature(name="f_trip_time_duration",
                                    feature_type=INT32,
-                                   transform="time_duration(lpep_pickup_datetime, lpep_dropoff_datetime, 'minutes')")
+                                   transform="(to_unix_timestamp(lpep_dropoff_datetime) - to_unix_timestamp(lpep_pickup_datetime))/60")
 
     features = [
         f_trip_distance,
@@ -163,7 +163,7 @@ def registry_test_setup(config_path: str):
 
     # use a new project name every time to make sure all features are registered correctly
     now = datetime.now()
-    os.environ["project_config__project_name"] =  ''.join(['feathr_ci','_', str(now.minute), '_', str(now.second), '_', str(now.microsecond)]) 
+    os.environ["project_config__project_name"] =  ''.join(['feathr_ci_registry','_', str(now.minute), '_', str(now.second), '_', str(now.microsecond)]) 
 
     client = FeathrClient(config_path=config_path, project_registry_tag={"for_test_purpose":"true"})
 

--- a/feathr_project/test/test_fixture.py
+++ b/feathr_project/test/test_fixture.py
@@ -185,8 +185,9 @@ def registry_test_setup(config_path: str):
                               registry_tags={"for_test_purpose":"true"}
                               )
     f_trip_time_duration = Feature(name="f_trip_time_duration",
-                                   feature_type=INT32,
-                                   transform="time_duration(lpep_pickup_datetime, lpep_dropoff_datetime, 'minutes')")
+                               feature_type=INT32,
+                               transform="(to_unix_timestamp(lpep_dropoff_datetime) - to_unix_timestamp(lpep_pickup_datetime))/60")
+
 
     features = [
         f_trip_distance,

--- a/feathr_project/test/test_user_workspace/feathr_config.yaml
+++ b/feathr_project/test/test_user_workspace/feathr_config.yaml
@@ -105,7 +105,7 @@ feature_registry:
   purview:
     # Registry configs
     # register type system in purview during feathr client initialization. This is only required to be executed once.
-    type_system_initialization: false
+    type_system_initialization: true
     # configure the name of the purview endpoint
     purview_name: 'feathrazuretest3-purview1'
     # delimiter indicates that how the project/workspace name, feature names etc. are delimited. By default it will be '__'


### PR DESCRIPTION
Goal of this PR is to solve some critical issues that the previous PR by @YihuiGuo didn't address. More specifically, it includes:
- Getting all the components from the registry back, including the correct keys, Transformation functions, UDFs, etc.
- Adding a `feature_config` field in the schema to enable further extensibility 
- Fix a few grammar issues in Python objects, otherwise they won't pass pylint
- Adding test to make sure that the features returned from the registry can actually run a job 