### PR TITLE
Changing illegal key vault secret name

### DIFF
--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -116,7 +116,7 @@
                 },
                 {
                     "type": "Microsoft.KeyVault/vaults/secrets",
-                    "name": "[concat(variables('keyVaultName'), '/REDIS_PASSWORD')]",
+                    "name": "[concat(variables('keyVaultName'), '/REDIS-PASSWORD')]",
                     "apiVersion": "2021-10-01",
                     "location": "[resourceGroup().location]",
                     "properties": {


### PR DESCRIPTION
This PR fixes a typo in the ARM template shown in the Feathr quickstart. Currently, the deploy to azure button fails to deploy because the secret name REDIS_PASSWORD is illegal .Secrets can only contain alphanumeric characters and dashes. Changing it to REDIS-PASSWORD to match the rest of the template. This secret is not used in the jupyter notebook shown in quick start, so does not need to be changed there. 