### PR TITLE
Fix test_feathr_register_features_e2e

### DIFF
--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -40,6 +40,7 @@ def test_feathr_register_features_e2e():
     # in CI test, the project name is set by the CI pipeline so we read it here
     all_features = client.list_registered_features(project_name=client.project_name)
     all_feature_names = [x['name'] for x in all_features]
+    
     assert 'f_is_long_trip_distance' in all_features # test regular ones
     assert 'f_trip_time_rounded' in all_feature_names # make sure derived features are there
     assert 'f_location_avg_fare' in all_feature_names # make sure aggregated features are there

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -39,11 +39,12 @@ def test_feathr_register_features_e2e():
     time.sleep(5)
     # in CI test, the project name is set by the CI pipeline so we read it here
     all_features = client.list_registered_features(project_name=client.project_name)
+    all_feature_names = [x['name'] for x in all_features]
     assert 'f_is_long_trip_distance' in all_features # test regular ones
-    assert 'f_trip_time_rounded' in all_features # make sure derived features are there
-    assert 'f_location_avg_fare' in all_features # make sure aggregated features are there
-    assert 'f_trip_time_rounded_plus' in all_features # make sure derived features are there 
-    assert 'f_trip_time_distance' in all_features # make sure derived features are there  
+    assert 'f_trip_time_rounded' in all_feature_names # make sure derived features are there
+    assert 'f_location_avg_fare' in all_feature_names # make sure aggregated features are there
+    assert 'f_trip_time_rounded_plus' in all_feature_names # make sure derived features are there 
+    assert 'f_trip_time_distance' in all_feature_names # make sure derived features are there  
 
     # Sync workspace from registry, will get all conf files back
     client.get_features_from_registry(client.project_name)


### PR DESCRIPTION
For API rendering. the return value of list_registered_features was changed from string array to object array.

However the pytest was not changed.


Related Issue: https://github.com/linkedin/feathr/issues/247