### PR TITLE
moved azure ad config to a .env file for better overriding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+#.env
 .venv
 env/
 venv/

--- a/ui/.env
+++ b/ui/.env
@@ -1,0 +1,2 @@
+REACT_APP_AAD_APP_CLIENT_ID=c8d4653e-ddaf-4154-a342-01e38ce5a4a0
+REACT_APP_AAD_APP_AUTHORITY=https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47

--- a/ui/src/react-app-env.d.ts
+++ b/ui/src/react-app-env.d.ts
@@ -1,1 +1,14 @@
 /// <reference types="react-scripts" />
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NODE_ENV: "development" | "production";
+      PORT?: string;
+      PWD: string;
+      REACT_APP_AAD_APP_CLIENT_ID: string;
+      REACT_APP_AAD_APP_AUTHORITY: string;
+    }
+  }
+}
+
+export {};

--- a/ui/src/router/routes.tsx
+++ b/ui/src/router/routes.tsx
@@ -1,11 +1,15 @@
-import React, { Suspense } from 'react';
-import { BrowserRouter, Route, Switch, withRouter } from 'react-router-dom';
-import { Layout } from 'antd';
+import React, { Suspense } from "react";
+import { BrowserRouter, Route, Switch, withRouter } from "react-router-dom";
+import { Layout } from "antd";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { Configuration, InteractionType, PublicClientApplication } from "@azure/msal-browser";
+import {
+  Configuration,
+  InteractionType,
+  PublicClientApplication,
+} from "@azure/msal-browser";
 import { MsalAuthenticationTemplate, MsalProvider } from "@azure/msal-react";
-import Header from '../components/header/header';
-import SideMenu from '../components/sidemenu/siteMenu';
+import Header from "../components/header/header";
+import SideMenu from "../components/sidemenu/siteMenu";
 import Features from "../pages/feature/features";
 import NewFeature from "../pages/feature/newFeature";
 import FeatureDetails from "../pages/feature/featureDetails";
@@ -14,35 +18,54 @@ import FeatureLineage from "../pages/feature/featureLineage";
 
 type Props = {};
 const queryClient = new QueryClient();
-const AAD_APP_CLIENT_ID = "c8d4653e-ddaf-4154-a342-01e38ce5a4a0";
-const AAD_APP_AUTHORITY = "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47";
+
 const msalConfig: Configuration = {
   auth: {
-    clientId: AAD_APP_CLIENT_ID,
-    authority: AAD_APP_AUTHORITY,
-    redirectUri: window.location.origin
-  }
+    clientId: process.env.REACT_APP_AAD_APP_CLIENT_ID,
+    authority: process.env.REACT_APP_AAD_APP_AUTHORITY,
+    redirectUri: window.location.origin,
+  },
 };
 const pca = new PublicClientApplication(msalConfig);
 const Routes: React.FC<Props> = () => {
   return (
-    <MsalProvider instance={ pca }>
-      <MsalAuthenticationTemplate interactionType={ InteractionType.Redirect }>
-        <QueryClientProvider client={ queryClient }>
+    <MsalProvider instance={pca}>
+      <MsalAuthenticationTemplate interactionType={InteractionType.Redirect}>
+        <QueryClientProvider client={queryClient}>
           <BrowserRouter>
-            <Layout style={ { minHeight: "100vh" } }>
+            <Layout style={{ minHeight: "100vh" }}>
               <SideMenu />
               <Layout>
                 <Header />
                 <Switch>
-                  <Suspense fallback={ <div /> }>
-                    <Route exact={ true } path="/dataSources" component={ withRouter(DataSources) } />
-                    <Route exact={ true } path="/features" component={ withRouter(Features) } />
-                    <Route exact={ true } path="/new-feature" component={ withRouter(NewFeature) } />
-                    <Route exact={ true } path="/projects/:project/features/:qualifiedName" component={ withRouter(FeatureDetails) } />
-                    <Route exact={ true } path="/projects/:project/features/:qualifiedName/lineage" component={ withRouter(FeatureLineage) } />
-                    {/* {publicRoutes} */ }
-                    {/* <Route component={NotFound} /> */ }
+                  <Suspense fallback={<div />}>
+                    <Route
+                      exact={true}
+                      path="/dataSources"
+                      component={withRouter(DataSources)}
+                    />
+                    <Route
+                      exact={true}
+                      path="/features"
+                      component={withRouter(Features)}
+                    />
+                    <Route
+                      exact={true}
+                      path="/new-feature"
+                      component={withRouter(NewFeature)}
+                    />
+                    <Route
+                      exact={true}
+                      path="/projects/:project/features/:qualifiedName"
+                      component={withRouter(FeatureDetails)}
+                    />
+                    <Route
+                      exact={true}
+                      path="/projects/:project/features/:qualifiedName/lineage"
+                      component={withRouter(FeatureLineage)}
+                    />
+                    {/* {publicRoutes} */}
+                    {/* <Route component={NotFound} /> */}
                   </Suspense>
                 </Switch>
               </Layout>
@@ -52,6 +75,6 @@ const Routes: React.FC<Props> = () => {
       </MsalAuthenticationTemplate>
     </MsalProvider>
   );
-}
+};
 
 export default Routes;


### PR DESCRIPTION
The routes.tsx file was containing the azure client id and authority hardcoded. This PR has moved these variables into an .env file which could be useful to override with .env.local file while running in local set up. 

.gitignore in main fethr repository was changed to allow .env file to be committed.