### PR TITLE
Feathr UI: redesign site header

### DIFF
--- a/ui/src/components/header/header.css
+++ b/ui/src/components/header/header.css
@@ -1,4 +1,18 @@
-.container {
+.dropdown-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 2px;
+    padding:2px 4px;
+    transition: all .3s;
+}
+
+.dropdown-trigger:hover {
+    cursor: pointer;
+    background: rgba(0,0,0,.025);
+}
+
+.layout-header {
     background-color: #fff;
     justify-content: space-between;
     display: flex;
@@ -9,7 +23,7 @@
     align-items: center;
 }
 
-.right-side {
+.layout-header-right {
     display: flex;
     flex-wrap: wrap;
     align-items: center;

--- a/ui/src/components/header/header.css
+++ b/ui/src/components/header/header.css
@@ -1,0 +1,17 @@
+.container {
+    background-color: #fff;
+    justify-content: space-between;
+    display: flex;
+    height: auto;
+    line-height: 48px;
+    padding: 0 25px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.right-side {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+}

--- a/ui/src/components/header/header.less
+++ b/ui/src/components/header/header.less
@@ -1,8 +1,0 @@
-@module: header;
-
-.@{module} {
-  padding: 12px;
-}
-
-@media (max-width: 767px) {
-}

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -1,52 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import { Button, PageHeader, Row, Typography } from 'antd';
+import React from 'react';
+import { Layout } from 'antd';
 import { useAccount, useMsal } from "@azure/msal-react";
-import './header.less';
+import './header.css';
+import HeaderDropdown from "./headerDropDown";
 
 type Props = {};
 
 const Header: React.FC<Props> = () => {
-  const { accounts, instance } = useMsal();
+  const { accounts } = useMsal();
   const account = useAccount(accounts[0] || {});
-  const [name, setName] = useState("");
-
-  useEffect(() => {
-    if (account && account.name) {
-      setName(account.name.split(" ")[0]);
-    }
-  }, [account]);
-
-  const onClickLogout = () => {
-    instance.logoutRedirect().catch(e => {
-      console.error(e);
-    });
-  }
-
-  const { Paragraph } = Typography;
+  console.log(account);
   return (
-    <PageHeader
-      title={ `Hello ${ name }, welcome to Feathr Feature Store` }
-      style={ { backgroundColor: "white", paddingLeft: "50px", paddingRight: "50px" } }
-      extra={ [<Button key="3" onClick={ onClickLogout }>Logout</Button>] }>
-      <Row>
-        <div style={ { flex: 1 } }>
-          <>
-            <Paragraph>
-              In this web ui, you can see Data Sources, Features and Jobs registered in Feathr. If you are new to
-              Feathr, please visit
-              <a target="_blank" href="https://linkedin.github.io/feathr/concepts/feathr-concepts-for-beginners.html"
-                 rel="noreferrer"> Feathr Concepts for Beginners
-              </a> to get start
-            </Paragraph>
-            <div>
-
-            </div>
-          </>
-        </div>
-      </Row>
-    </PageHeader>
+    <Layout.Header className="container" style={{  backgroundColor: '#fff' }}>
+      <span>In Feathr Feature Store, you can manage and share features.
+        <a target="_blank" rel="noreferrer"
+           href="https://linkedin.github.io/feathr/concepts/feathr-concepts-for-beginners.html"> Learn More</a>
+      </span>
+      <span className='right-side'><HeaderDropdown name={ account?.username } /></span>
+    </Layout.Header>
   );
 };
-
 
 export default Header;

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -2,21 +2,21 @@ import React from 'react';
 import { Layout } from 'antd';
 import { useAccount, useMsal } from "@azure/msal-react";
 import './header.css';
-import HeaderDropdown from "./headerDropDown";
+import HeaderWidget from "./headerWidget";
 
 type Props = {};
-
 const Header: React.FC<Props> = () => {
   const { accounts } = useMsal();
   const account = useAccount(accounts[0] || {});
-  console.log(account);
   return (
-    <Layout.Header className="container" style={{  backgroundColor: '#fff' }}>
+    <Layout.Header className="layout-header" style={ { backgroundColor: "#fff", height : "auto" } }>
       <span>In Feathr Feature Store, you can manage and share features.
         <a target="_blank" rel="noreferrer"
            href="https://linkedin.github.io/feathr/concepts/feathr-concepts-for-beginners.html"> Learn More</a>
       </span>
-      <span className='right-side'><HeaderDropdown name={ account?.username } /></span>
+      <span className='layout-header-right'>
+        <HeaderWidget username={ account?.username } />
+      </span>
     </Layout.Header>
   );
 };

--- a/ui/src/components/header/headerDropDown.tsx
+++ b/ui/src/components/header/headerDropDown.tsx
@@ -1,0 +1,60 @@
+import { Dropdown, Menu, Avatar } from "antd";
+import React from "react";
+import { LogoutOutlined, UserOutlined } from '@ant-design/icons';
+import { useMsal } from "@azure/msal-react";
+
+// @ts-ignore
+const menuHeaderDropdown = (instance) => {
+  const menuItems = [
+    {
+      key: 'logout',
+      icon: <LogoutOutlined />,
+      value: 'Logout',
+      callback: () => {
+        // @ts-ignore
+        instance.logoutRedirect().catch(e => {
+          console.error(e);
+        });
+      }
+    }
+  ];
+  // @ts-ignore
+  const onClick = ({ key }) => {
+    const item = menuItems.find(i => i.key === key);
+    if (item && item.callback)
+      item.callback();
+  };
+  return (
+    <Menu onClick={ onClick } selectedKeys={ [] }>
+      { menuItems.map(item => {
+        const { key, icon, value } = item;
+        return (
+          <Menu.Item key={ key }>
+            { icon }
+            <span>{ value }</span>
+          </Menu.Item>);
+      }) }
+    </Menu>
+  );
+}
+
+// @ts-ignore
+const HeaderDropdown = props => {
+  const { instance } = useMsal();
+  const { name: username } = props;
+  if (!username)
+    return null;
+  return (
+    <Dropdown
+      overlay={ menuHeaderDropdown(instance) }
+      { ...props }
+    >
+      <div className='header-container'>
+        <Avatar size="small" style={ { marginRight: 4 } } icon={ <UserOutlined /> } />
+        <span>{ username }</span>
+      </div>
+    </Dropdown>
+  )
+};
+
+export default HeaderDropdown;

--- a/ui/src/components/header/headerWidget.tsx
+++ b/ui/src/components/header/headerWidget.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Dropdown, Avatar } from "antd";
+import { UserOutlined } from '@ant-design/icons';
+import { useMsal } from "@azure/msal-react";
+import HeaderWidgetMenu from "./headerWidgetMenu";
+
+type Props = { username?: string };
+const HeaderWidget: React.FC<Props> = ({ username }) => {
+  const { instance } = useMsal();
+  if (!username) {
+    return null;
+  }
+  return (
+    <Dropdown overlay={ <HeaderWidgetMenu instance={ instance } /> }>
+      <div className='dropdown-trigger'>
+        <Avatar size="small" style={ { marginRight: 4 } } icon={ <UserOutlined /> } />
+        <span>{ username }</span>
+      </div>
+    </Dropdown>
+  )
+};
+
+export default HeaderWidget;

--- a/ui/src/components/header/headerWidgetMenu.tsx
+++ b/ui/src/components/header/headerWidgetMenu.tsx
@@ -1,17 +1,16 @@
-import { Dropdown, Menu, Avatar } from "antd";
 import React from "react";
-import { LogoutOutlined, UserOutlined } from '@ant-design/icons';
-import { useMsal } from "@azure/msal-react";
+import { LogoutOutlined } from "@ant-design/icons";
+import { Menu } from "antd";
+import { IPublicClientApplication } from "@azure/msal-browser";
 
-// @ts-ignore
-const menuHeaderDropdown = (instance) => {
+type Props = { instance: IPublicClientApplication };
+const HeaderWidgetMenu: React.FC<Props> = ({ instance }) => {
   const menuItems = [
     {
       key: 'logout',
       icon: <LogoutOutlined />,
       value: 'Logout',
       callback: () => {
-        // @ts-ignore
         instance.logoutRedirect().catch(e => {
           console.error(e);
         });
@@ -38,23 +37,4 @@ const menuHeaderDropdown = (instance) => {
   );
 }
 
-// @ts-ignore
-const HeaderDropdown = props => {
-  const { instance } = useMsal();
-  const { name: username } = props;
-  if (!username)
-    return null;
-  return (
-    <Dropdown
-      overlay={ menuHeaderDropdown(instance) }
-      { ...props }
-    >
-      <div className='header-container'>
-        <Avatar size="small" style={ { marginRight: 4 } } icon={ <UserOutlined /> } />
-        <span>{ username }</span>
-      </div>
-    </Dropdown>
-  )
-};
-
-export default HeaderDropdown;
+export default HeaderWidgetMenu;

--- a/ui/src/components/sidemenu/siteMenu.tsx
+++ b/ui/src/components/sidemenu/siteMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Layout, Menu } from 'antd';
-import { CopyOutlined, DatabaseOutlined, RocketOutlined } from '@ant-design/icons';
+import { CopyOutlined, DatabaseOutlined, EyeOutlined, RocketOutlined } from '@ant-design/icons';
 import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
 
@@ -12,7 +12,6 @@ const SideMenu = withRouter(({ history }) => {
       <div style={ { fontSize: 'medium', color: 'white', margin: '10px', paddingLeft: '15px' } }>
         Feathr Web UI
       </div>
-
       <Menu
         theme="dark"
         mode="inline"
@@ -27,7 +26,10 @@ const SideMenu = withRouter(({ history }) => {
           <Link to="/features">Features</Link>
         </Menu.Item>
         <Menu.Item key="/jobs" icon={ <RocketOutlined /> }>
-          <Link to="/">Jobs</Link>
+          <Link to="/jobs">Jobs</Link>
+        </Menu.Item>
+        <Menu.Item key="/monitoring" icon={ <EyeOutlined /> }>
+          <Link to="/monitoring">Monitoring</Link>
         </Menu.Item>
       </Menu>
     </Sider>

--- a/ui/src/pages/jobs/jobs.tsx
+++ b/ui/src/pages/jobs/jobs.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Card} from 'antd';
+
+type Props = {};
+
+const Jobs: React.FC<Props> = () => {
+  return (
+    <div className="home" style={ { margin: "2%" } }>
+      <Card style={ { minWidth: '1000px' } }>
+        Under construction
+      </Card>
+    </div>
+  );
+};
+
+export default Jobs;

--- a/ui/src/pages/monitoring/monitoring.tsx
+++ b/ui/src/pages/monitoring/monitoring.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Card} from 'antd';
+
+type Props = {};
+
+const Monitoring: React.FC<Props> = () => {
+  return (
+    <div className="home" style={ { margin: "2%" } }>
+      <Card style={ { minWidth: '1000px' } }>
+        Under construction
+      </Card>
+    </div>
+  );
+};
+
+export default Monitoring;

--- a/ui/src/router/routes.tsx
+++ b/ui/src/router/routes.tsx
@@ -11,6 +11,8 @@ import NewFeature from "../pages/feature/newFeature";
 import FeatureDetails from "../pages/feature/featureDetails";
 import DataSources from "../pages/dataSource/dataSources";
 import FeatureLineage from "../pages/feature/featureLineage";
+import Jobs from "../pages/jobs/jobs";
+import Monitoring from "../pages/monitoring/monitoring";
 
 type Props = {};
 const queryClient = new QueryClient();
@@ -41,6 +43,8 @@ const Routes: React.FC<Props> = () => {
                     <Route exact={ true } path="/new-feature" component={ withRouter(NewFeature) } />
                     <Route exact={ true } path="/projects/:project/features/:qualifiedName" component={ withRouter(FeatureDetails) } />
                     <Route exact={ true } path="/projects/:project/features/:qualifiedName/lineage" component={ withRouter(FeatureLineage) } />
+                    <Route exact={ true } path="/jobs" component={ withRouter(Jobs) } />
+                    <Route exact={ true } path="/monitoring" component={ withRouter(Monitoring) } />
                     {/* {publicRoutes} */ }
                     {/* <Route component={NotFound} /> */ }
                   </Suspense>


### PR DESCRIPTION
This PR makes following feathr ui site header changes

- Display username in header, add avatar
- Move logout button to a dropdown triggered by hover
- Shorten site description to make more rooms to site content pages.