### PR TITLE
Feathr UI: enable multiple tenant auth

### DIFF
--- a/ui/.env
+++ b/ui/.env
@@ -1,2 +1,2 @@
-REACT_APP_AAD_APP_CLIENT_ID=c8d4653e-ddaf-4154-a342-01e38ce5a4a0
-REACT_APP_AAD_APP_AUTHORITY=https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47
+REACT_APP_AAD_APP_CLIENT_ID=db8dc4b0-202e-450c-b38d-7396ad9631a5
+REACT_APP_AAD_APP_AUTHORITY=https://login.microsoftonline.com/common

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
-# Feathr UI
+# Feathr Feature Store UI
 
-This is Feathr web ui frontend code
+This directory hosts Feathr Feature Store UI code. Visit [demo site](https://aka.ms/feathrdemo) to try Feathr Feature Store UI,
 
 ## Prerequisites
 Install the latest version of [NodeJS](https://nodejs.org/en/) LTS v14.x or v16.x. Make sure to use npm no later than 6.x. Run `node --version` and `npm --version` to verify installed versions.


### PR DESCRIPTION
This PR enables multiple tenants on feathr UI. After this change, feathr ui demo site https://aka.ms/feathrdemo will be accessible to following users

- All users with a work or school organization accounts, includes Office 365 subscribers.
- All users with an account can access to Skype, Outlook.com, OneDrive, and Xbox LIVE, aka Personal Microsoft account

Staging site: https://brave-moss-045d2ce00-4.eastasia.1.azurestaticapps.net

Closes #265 