### PR TITLE
Fix test failure

### DIFF
--- a/feathr_project/test/test_azure_snowflake_e2e.py
+++ b/feathr_project/test/test_azure_snowflake_e2e.py
@@ -41,7 +41,7 @@ def test_feathr_online_store_agg_features():
     assert len(res) == 2
     assert res[0] != None
     assert res[1] != None
-    res = client.multi_get_online_features('snowflakeSampleDemoFeature',
+    res = client.multi_get_online_features(online_test_table,
                                     ['1', '2'],
                                     ['f_snowflake_call_center_division_name', 'f_snowflake_call_center_zipcode'])
     assert res['1'][0] != None

--- a/feathr_project/test/test_feature_registry.py
+++ b/feathr_project/test/test_feature_registry.py
@@ -60,7 +60,7 @@ def test_feathr_register_features_e2e():
     client.get_offline_features(observation_settings=settings,
                                 feature_query=feature_query,
                                 output_path=output_path)
-    client.wait_job_to_finish(timeout_sec=500)
+    client.wait_job_to_finish(timeout_sec=900)
 
 
     


### PR DESCRIPTION
This PR fixes the test failure in main:
1. Change the Redis table name in one of the test to make sure it's using the right method for online tables
2. extend some test wait time to avoid time out issues