### PR TITLE
Add 'feathr hocon' command

### DIFF
--- a/feathr_project/feathr/_feature_registry.py
+++ b/feathr_project/feathr/_feature_registry.py
@@ -581,12 +581,12 @@ class _FeatureRegistry():
         return definitions
 
     @classmethod
-    def save_to_feature_config(self, workspace_path: Path):
+    def save_to_feature_config(self, workspace_path: Path, config_save_dir: Path):
         """Save feature definition within the workspace into HOCON feature config files"""
         repo_definitions = self._extract_features(workspace_path)
-        self._save_request_feature_config(repo_definitions)
-        self._save_anchored_feature_config(repo_definitions)
-        self._save_derived_feature_config(repo_definitions)
+        self._save_request_feature_config(repo_definitions, config_save_dir)
+        self._save_anchored_feature_config(repo_definitions, config_save_dir)
+        self._save_derived_feature_config(repo_definitions, config_save_dir)
 
     @classmethod
     def save_to_feature_config_from_context(self, anchor_list, derived_feature_list, local_workspace_dir: Path):

--- a/feathr_project/feathr/source.py
+++ b/feathr_project/feathr/source.py
@@ -103,7 +103,7 @@ class HdfsSource(Source):
         tm = Template("""  
             {{source.name}}: {
                 location: {path: "{{source.path}}"}
-                {% if source.event_timestamp_column is defined %}
+                {% if source.event_timestamp_column %}
                     timeWindowParameters: {
                         timestampColumn: "{{source.event_timestamp_column}}"
                         timestampColumnFormat: "{{source.timestamp_format}}"

--- a/feathr_project/feathrcli/cli.py
+++ b/feathr_project/feathrcli/cli.py
@@ -7,7 +7,7 @@ import distutils.dir_util
 import subprocess
 import urllib.request
 from feathr.client import FeathrClient
-
+from feathr._feature_registry import _FeatureRegistry
 
 @click.group()
 @click.pass_context
@@ -69,6 +69,18 @@ def init(name, git):
                                'wiki to learn how to manage '
                                'your workspace with git.', fg='green'))
     click.echo(click.style('Feathr initialization completed.', fg='green'))
+
+
+@cli.command()
+@click.option('--save_to', default="./", help='Specify the path to save the output HOCON config(relative to current path).')
+def hocon(save_to):
+    """
+    Scan all Python-based feature definitions recursively under current directory,
+     convert them to HOCON config and save to a given path (relative to current directory).
+    """
+    scan_dir = Path.cwd()
+    save_to = Path(os.path.join(scan_dir, save_to))
+    _FeatureRegistry.save_to_feature_config(scan_dir, save_to)
 
 
 @cli.command()


### PR DESCRIPTION
Add a new CLI command line "feathr hocon", which scans all Python-based feature definitions recursively under current directory, convert them to HOCON config and save to a given path (relative to current directory). 

Usage:
`feathr hocon`
`feathr hocon --save_to=../features`