### PR TITLE
#326 Azure Synapse client doesn't have job_url

### DIFF
--- a/feathr_project/feathr/_synapse_submission.py
+++ b/feathr_project/feathr/_synapse_submission.py
@@ -135,7 +135,7 @@ class _FeathrSynapseJobLauncher(SparkJobLauncher):
             if status in {LivyStates.SUCCESS.value}:
                 return True
             elif status in {LivyStates.ERROR.value, LivyStates.DEAD.value, LivyStates.KILLED.value}:
-                logger.error("Feathr job has failed. Please visit this page to view error message: {}", self.job_url)
+                logger.error("Feathr job has failed.")
                 logger.error(self._api.get_driver_log(self.current_job_info.id))
                 return False
             else:


### PR DESCRIPTION
#326
Azure Synapse client doesn't have `job_url`, remove it from the error log.