### PR TITLE
enable JWT token param in frontend API calls

### DIFF
--- a/ui/src/api/api.tsx
+++ b/ui/src/api/api.tsx
@@ -161,8 +161,8 @@ export const getIdToken = async( msalInstance: PublicClientApplication ): Promis
       scopes: ["User.Read"],
       account: activeAccount || accounts[0]
   };
+  // Silently acquire an token for a given set of scopes. Will use cached token if available, otherwise will attempt to acquire a new token from the network via refresh token.
   await msalInstance.acquireTokenSilent(request).then(response => {
-    console.log(response.idToken)
     return response.idToken
   }).catch(error => {
      if (error instanceof InteractionRequiredAuthError) {

--- a/ui/src/api/api.tsx
+++ b/ui/src/api/api.tsx
@@ -9,7 +9,7 @@ const MOCK_TOKEN = "mockAppServiceKey";
 const msalInstance = getMsalConfig();
 
 export const fetchDataSources = async (project: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .get<DataSource[]>(`${ API_ENDPOINT }/projects/${ project }/datasources?code=${ token }`,
       { headers: {} })
@@ -19,7 +19,7 @@ export const fetchDataSources = async (project: string) => {
 };
 
 export const fetchProjects = async () => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .get<[]>(`${ API_ENDPOINT }/projects?code=${ token }`,
       {
@@ -31,7 +31,7 @@ export const fetchProjects = async () => {
 };
 
 export const fetchFeatures = async (project: string, page: number, limit: number, keyword: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .get<Feature[]>(`${ API_ENDPOINT }/projects/${ project }/features?code=${ token }`,
       {
@@ -44,7 +44,7 @@ export const fetchFeatures = async (project: string, page: number, limit: number
 };
 
 export const fetchFeature = async (project: string, featureId: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .get<Feature>(`${ API_ENDPOINT }/features/${ featureId }?code=${ token }`, {})
     .then((response) => {
@@ -53,7 +53,7 @@ export const fetchFeature = async (project: string, featureId: string) => {
 };
 
 export const fetchProjectLineages = async (project: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .get<FeatureLineage>(`${ API_ENDPOINT }/projects/${ project }?code=${ token }`, {})
     .then((response) => {
@@ -62,7 +62,7 @@ export const fetchProjectLineages = async (project: string) => {
 };
 
 export const fetchFeatureLineages = async (project: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .get<FeatureLineage>(`${ API_ENDPOINT }/features/lineage/${ project }?code=${ token }`, {})
     .then((response) => {
@@ -72,7 +72,7 @@ export const fetchFeatureLineages = async (project: string) => {
 
 // Following are place-holder code
 export const createFeature = async (feature: Feature) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return Axios
     .post(`${ API_ENDPOINT }/features?code=${ token }`, feature,
       {
@@ -86,7 +86,7 @@ export const createFeature = async (feature: Feature) => {
 }
 
 export const updateFeature = async (feature: Feature, id: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   feature.guid = id;
   return await Axios.put(`${ API_ENDPOINT }/features/${ id }?code=${ token }`, feature,
     {
@@ -100,7 +100,7 @@ export const updateFeature = async (feature: Feature, id: string) => {
 };
 
 export const deleteFeature = async (qualifiedName: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return await Axios
     .delete(`${ API_ENDPOINT }/features/${ qualifiedName }?code=${ token }`,
       {
@@ -119,7 +119,7 @@ export const listUserRole = async () => {
 };
 
 export const getUserRole = async (userName: string) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return await Axios
   .get<UserRole>(`${ API_ENDPOINT }/user/${userName}/userroles?code=${ token }`, {})
   .then((response) => {
@@ -128,7 +128,7 @@ export const getUserRole = async (userName: string) => {
 }
 
 export const addUserRole = async (role: Role) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return await Axios
   .post(`${ API_ENDPOINT }/user/${role.userName}/userroles/new?code=${ token }`, role,
       {
@@ -142,7 +142,7 @@ export const addUserRole = async (role: Role) => {
 }
 
 export const deleteUserRole = async (role: Role) => {
-  const token = await getAccessToken(msalInstance);
+  const token = await getIdToken(msalInstance);
   return await Axios
   .post(`${ API_ENDPOINT }/user/${role.userName}/userroles/delete?code=${ token }`, role,
       {
@@ -155,7 +155,7 @@ export const deleteUserRole = async (role: Role) => {
     });
 }
 
-export const getAccessToken = async( msalInstance: PublicClientApplication ): Promise<string> => {
+export const getIdToken = async( msalInstance: PublicClientApplication ): Promise<string> => {
   const activeAccount = msalInstance.getActiveAccount(); // This will only return a non-null value if you have logic somewhere else that calls the setActiveAccount API
   const accounts = msalInstance.getAllAccounts();
   const request = {
@@ -163,11 +163,12 @@ export const getAccessToken = async( msalInstance: PublicClientApplication ): Pr
       account: activeAccount || accounts[0]
   };
   await msalInstance.acquireTokenSilent(request).then(response => {
-    return response.accessToken
+    console.log(response.idToken)
+    return response.idToken
   }).catch(error => {
      if (error instanceof InteractionRequiredAuthError) {
        msalInstance.acquireTokenPopup(request).then(response => {
-         return response.accessToken
+         return response.idToken
         });
     }
     })

--- a/ui/src/api/api.tsx
+++ b/ui/src/api/api.tsx
@@ -5,7 +5,6 @@ import mockUserRole from "./mock/userrole.json";
 import { getMsalConfig } from "../utils/utils";
 
 const API_ENDPOINT = process.env.REACT_APP_API_ENDPOINT + "/api/v1";
-const MOCK_TOKEN = "mockAppServiceKey";
 const msalInstance = getMsalConfig();
 
 export const fetchDataSources = async (project: string) => {
@@ -172,5 +171,5 @@ export const getIdToken = async( msalInstance: PublicClientApplication ): Promis
         });
     }
     })
-    return MOCK_TOKEN
+    return ""
 }

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Layout } from "antd";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { Configuration, InteractionType, PublicClientApplication, } from "@azure/msal-browser";
+import { InteractionType } from "@azure/msal-browser";
 import { MsalAuthenticationTemplate, MsalProvider } from "@azure/msal-react";
 import Header from "./components/header/header";
 import SideMenu from "./components/sidemenu/siteMenu";
@@ -15,17 +15,11 @@ import Monitoring from "./pages/monitoring/monitoring";
 import LineageGraph from "./pages/feature/lineageGraph";
 import Management from "./pages/management/management";
 import RoleManagement from "./pages/management/roleManagement";
+import { getMsalConfig } from "./utils/utils";
 
 const queryClient = new QueryClient();
 
-const msalConfig: Configuration = {
-  auth: {
-    clientId: process.env.REACT_APP_AAD_APP_CLIENT_ID,
-    authority: process.env.REACT_APP_AAD_APP_AUTHORITY,
-    redirectUri: window.location.origin,
-  },
-};
-const msalClient = new PublicClientApplication(msalConfig);
+const msalClient = getMsalConfig();
 const App: React.FC = () => {
   return (
     <MsalProvider instance={ msalClient }>

--- a/ui/src/utils/utils.tsx
+++ b/ui/src/utils/utils.tsx
@@ -1,0 +1,12 @@
+import { Configuration, PublicClientApplication } from "@azure/msal-browser";
+
+export const getMsalConfig = () => {
+    const msalConfig: Configuration = {
+        auth: {
+          clientId: process.env.REACT_APP_AAD_APP_CLIENT_ID,
+          authority: process.env.REACT_APP_AAD_APP_AUTHORITY,
+          redirectUri: window.location.origin,
+        },
+      };   
+    return new PublicClientApplication(msalConfig);
+}


### PR DESCRIPTION
- Enable JWT token to replace current hardcode mock token.
- Protect all API calls with JWT token
- Abstract MsalInstance logic into `utils.tsx`