### PR TITLE
add license, release, docs, python api ref badges with shields img

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Feathr – An Enterprise-Grade, High Performance Feature Store
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue)](https://github.com/linkedin/feathr/blob/main/LICENSE)
+[![GitHub Release](https://img.shields.io/github/v/release/linkedin/feathr.svg?style=flat&sort=semver&color=blue)](https://github.com/linkedin/feathr/releases)
+[![Docs Latest](https://img.shields.io/badge/docs-latest-blue.svg)](https://linkedin.github.io/feathr/)
+[![Python API](https://img.shields.io/readthedocs/feathr?label=Python%20API)](https://feathr.readthedocs.io/en/latest/)
+
 ## What is Feathr?
 
 Feathr is the feature store that is used in production in LinkedIn for many years and was open sourced in April 2022. Read our announcement on [Open Sourcing Feathr](https://engineering.linkedin.com/blog/2022/open-sourcing-feathr---linkedin-s-feature-store-for-productive-m) and [Feathr on Azure](https://azure.microsoft.com/en-us/blog/feathr-linkedin-s-feature-store-is-now-available-on-azure/).


### PR DESCRIPTION
This PR includes 4 essential badges:
![image](https://user-images.githubusercontent.com/26561033/173520129-51d7cb9e-9bbc-4f35-830f-b4109136d979.png)

Other information like unit test status or Issue/PR status can also be summarized in this format:
![image](https://user-images.githubusercontent.com/26561033/173522573-12da6c9e-40fc-45f1-9cc3-9eb500d566db.png)
To keep content clean, I prefer not to put them in the main page. However, it could be useful for contributors and approvers. So we may consider to put them in dev doc page or some where else. 
If needed, I can add them in a separate PR. 