### PR TITLE
add links to Azure Key Vault name convert logic in quick start guide.

### DIFF
--- a/docs/how-to-guides/feathr-configuration-and-env.md
+++ b/docs/how-to-guides/feathr-configuration-and-env.md
@@ -111,4 +111,8 @@ Delimiter indicates that how the project name, feature names etc. are delimited.
 
 Feathr has native integrations with Azure Key Vault to make it more secure to access resources. However, Azure Key Vault doesn't support the secret name to have underscore `_` in the secret name. Feathr will automatically convert underscore `_` to dash `-`. For example, Feathr will look for `ONLINE-STORE--REDIS--HOST` in Azure Key Vault if the actual environment variable is `ONLINE_STORE__REDIS__HOST`.
 
+Please refer to [akv_client.py](https://github.com/linkedin/feathr/blob/main/feathr_project/feathr/secrets/akv_client.py) to understand the secret name convert logic. 
+
 Azure Key Vault is not case sensitive, so `online_store__redis__host` and `ONLINE_STORE__REDIS__HOST` will result in the same request to Azure Key Vault and yield the same result.
+
+You can automatically store resource credentials in provision stage, just like [azure_resource_provision.json](https://github.com/linkedin/feathr/blob/main/docs/how-to-guides/azure_resource_provision.json) do for `REDIS-PASSWORD`.

--- a/docs/quickstart_synapse.md
+++ b/docs/quickstart_synapse.md
@@ -101,7 +101,7 @@ os.environ['ONLINE_STORE__REDIS__HOST'] = 'feathrazure.redis.cache.windows.net'
 
 In the self-contained [sample notebook](https://github.com/linkedin/feathr/blob/main/feathr_project/feathrcli/data/feathr_user_workspace/product_recommendation_demo.ipynb), you also have to setup a few environment variables like below in order to access those cloud resources. You should be able to get those values from the first step.
 
-These values can also be reterived by using cloud key value store, such as [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/):
+These values can also be retrieved by using cloud key value store, such as [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/):
 
 ```python
 import os
@@ -110,6 +110,7 @@ os.environ['AZURE_CLIENT_ID'] = ''
 os.environ['AZURE_TENANT_ID'] = ''
 os.environ['AZURE_CLIENT_SECRET'] = ''
 ```
+Please refer to [A note on using azure key vault to store credentials](https://github.com/linkedin/feathr/blob/41e7496b38c43af6d7f8f1de842f657b27840f6d/docs/how-to-guides/feathr-configuration-and-env.md#a-note-on-using-azure-key-vault-to-store-credentials) for more details.
 
 ## Step 6: Create features with Python APIs
 


### PR DESCRIPTION
- add link to convert logic code in key vault note
- add link to key vault generation piece in provision template
- add link to key vault note in quick start guide
- fix typo