### PR TITLE
Add SQL server resources

### DIFF
--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -83,7 +83,7 @@
       "type": "string",
       "defaultValue": "https://xchfeathrtest4sto.blob.core.windows.net/public/feathr-2022-6-16-18-16.bacpac",
       "metadata": {
-        "description": "Specifies the URL of the BACPAC file."
+        "description": "This is the pre-created BACPAC file that contains required schemas by the registry server."
       }
     }
   },

--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -39,6 +39,52 @@
       "metadata": {
         "description": "Whether or not to deploy eventhub provision script"
       }
+    },
+    "databaseServerName": {
+      "type": "string",
+      "defaultValue": "[concat('server-', uniqueString(resourceGroup().id, deployment().name))]",
+      "metadata": {
+        "description": "Specifies the name for the SQL server"
+      }
+    },
+    "databaseName": {
+      "type": "string",
+      "defaultValue": "[concat('db-', uniqueString(resourceGroup().id, deployment().name), '-1')]",
+      "metadata": {
+        "description": "Specifies the name for the SQL database under the SQL server"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location for server and database"
+      }
+    },
+    "adminUser": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the username for admin"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Specifies the password for admin"
+      }
+    },
+    "storageAccountKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the key of the storage account where the BACPAC file is stored."
+      }
+    },
+    "bacpacUrl": {
+      "type": "string",
+      "defaultValue": "https://xchfeathrtest4sto.blob.core.windows.net/public/feathr-2022-6-16-18-16.bacpac",
+      "metadata": {
+        "description": "Specifies the URL of the BACPAC file."
+      }
     }
   },
   "variables": {
@@ -313,6 +359,59 @@
         "principalId": "[parameters('principalId')]",
         "scope": "[resourceGroup().id]"
       }
+    },
+    {
+      "type": "Microsoft.Sql/servers",
+      "apiVersion": "2021-02-01-preview",
+      "name": "[parameters('databaseServerName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "administratorLogin": "[parameters('adminUser')]",
+        "administratorLoginPassword": "[parameters('adminPassword')]",
+        "version": "12.0"
+      },
+      "resources": [
+        {
+          "type": "firewallrules",
+          "apiVersion": "2021-02-01-preview",
+          "name": "AllowAllAzureIps",
+          "location": "[parameters('location')]",
+          "dependsOn": [
+            "[parameters('databaseServerName')]"
+          ],
+          "properties": {
+            "startIpAddress": "0.0.0.0",
+            "endIpAddress": "0.0.0.0"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Sql/servers/databases",
+      "apiVersion": "2021-02-01-preview",
+      "name": "[concat(string(parameters('databaseServerName')), '/', string(parameters('databaseName')))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Sql/servers/', parameters('databaseServerName'))]"
+      ],
+      "resources": [
+        {
+          "type": "extensions",
+          "apiVersion": "2014-04-01",
+          "name": "Import",
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers/databases', parameters('databaseServerName'), parameters('databaseName'))]"
+          ],
+          "properties": {
+            "storageKeyType": "StorageAccessKey",
+            "storageKey": "[parameters('storageAccountKey')]",
+            "storageUri": "[parameters('bacpacUrl')]",
+            "administratorLogin": "[parameters('adminUser')]",
+            "administratorLoginPassword": "[parameters('adminPassword')]",
+            "operationMode": "Import"
+          }
+        }
+      ]
     }
   ],
   "outputs": {}

--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -81,7 +81,7 @@
     },
     "bacpacUrl": {
       "type": "string",
-      "defaultValue": "https://xchfeathrtest4sto.blob.core.windows.net/public/feathr-2022-6-16-18-16.bacpac",
+      "defaultValue": "https://azurefeathrstorage.blob.core.windows.net/public/feathr-registry-schema.bacpac",
       "metadata": {
         "description": "This is the pre-created BACPAC file that contains required schemas by the registry server."
       }

--- a/docs/how-to-guides/azure_resource_provision.json
+++ b/docs/how-to-guides/azure_resource_provision.json
@@ -362,7 +362,7 @@
     },
     {
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2021-02-01-preview",
+      "apiVersion": "2021-11-01-preview",
       "name": "[parameters('databaseServerName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -373,7 +373,7 @@
       "resources": [
         {
           "type": "firewallrules",
-          "apiVersion": "2021-02-01-preview",
+          "apiVersion": "2021-11-01-preview",
           "name": "AllowAllAzureIps",
           "location": "[parameters('location')]",
           "dependsOn": [
@@ -388,7 +388,7 @@
     },
     {
       "type": "Microsoft.Sql/servers/databases",
-      "apiVersion": "2021-02-01-preview",
+      "apiVersion": "2021-11-01-preview",
       "name": "[concat(string(parameters('databaseServerName')), '/', string(parameters('databaseName')))]",
       "location": "[parameters('location')]",
       "dependsOn": [
@@ -397,7 +397,7 @@
       "resources": [
         {
           "type": "extensions",
-          "apiVersion": "2014-04-01",
+          "apiVersion": "2021-11-01-preview",
           "name": "Import",
           "dependsOn": [
             "[resourceId('Microsoft.Sql/servers/databases', parameters('databaseServerName'), parameters('databaseName'))]"


### PR DESCRIPTION
Add SQL server resources.
Predefined tables required by the registry is included as a BACPAC file, which I have to put in another storage account because I don't have access to the subscription used by Feathr publications. But it's just the default value and can be overridden on deployment.

NOTE: This PR is to **add resources only**, Richin is still working at the same place to provide a full template with all components fully integrated, along with the document.