### PR TITLE
Refreshed JDBC support

### DIFF
--- a/feathr_project/feathr/spark_provider/_abc.py
+++ b/feathr_project/feathr/spark_provider/_abc.py
@@ -19,7 +19,7 @@ class SparkJobLauncher(ABC):
     @abstractmethod
     def submit_feathr_job(self, job_name: str, main_jar_path: str,  main_class_name: str, arguments: List[str],
                           reference_files_path: List[str], job_tags: Dict[str, str] = None,
-                          configuration: Dict[str, str] = {}):
+                          configuration: Dict[str, str] = {}, properties: Dict[str, str] = None):
         """
         Submits the feathr job
 
@@ -27,9 +27,10 @@ class SparkJobLauncher(ABC):
             job_name (str): name of the job
             main_jar_path (str): main file paths, usually your main jar file
             main_class_name (str): name of your main class
-            arguments (str): all the arugments you want to pass into the spark job
-            job_tags (str): tags of the job, for exmaple you might want to put your user ID, or a tag with a certain information
+            arguments (str): all the arguments you want to pass into the spark job
+            job_tags (str): tags of the job, for example you might want to put your user ID, or a tag with a certain information
             configuration (Dict[str, str]): Additional configs for the spark job
+            properties (Dict[str, str]): Additional System Properties for the spark job
         """
         pass
     @abstractmethod

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -116,7 +116,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
         DbfsApi(self.api_client).cp(recursive=True, overwrite=True, src=local_path, dst=returned_path)
         return returned_path
 
-    def submit_feathr_job(self, job_name: str, main_jar_path: str,  main_class_name: str, arguments: List[str], python_files: List[str], reference_files_path: List[str] = [], job_tags: Dict[str, str] = None, configuration: Dict[str, str] = {}):
+    def submit_feathr_job(self, job_name: str, main_jar_path: str,  main_class_name: str, arguments: List[str], python_files: List[str], reference_files_path: List[str] = [], job_tags: Dict[str, str] = None, configuration: Dict[str, str] = {}, properties: Dict[str, str] = {}):
         """
         submit the feathr job to databricks
         Refer to the databricks doc for more details on the meaning of the parameters:
@@ -124,10 +124,14 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
         Args:
             main_file_path (str): main file paths, usually your main jar file
             main_class_name (str): name of your main class
-            arguments (str): all the arugments you want to pass into the spark job
-            job_tags (str): tags of the job, for exmaple you might want to put your user ID, or a tag with a certain information
+            arguments (str): all the arguments you want to pass into the spark job
+            job_tags (str): tags of the job, for example you might want to put your user ID, or a tag with a certain information
             configuration (Dict[str, str]): Additional configs for the spark job
+            properties (Dict[str, str]): Additional System Properties for the spark job
         """
+
+        if properties:
+            arguments.append("--system-properties=%s" % json.dumps(properties))
 
         if isinstance(self.config_template, str):
             # if the input is a string, load it directly
@@ -174,7 +178,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
 
         result = RunsApi(self.api_client).get_run(self.res_job_id)
         self.job_url = result['run_page_url']
-        logger.info('Feathr job Submitted Sucessfully. View more details here: {}', self.job_url)
+        logger.info('Feathr job Submitted Successfully. View more details here: {}', self.job_url)
 
         # return ID as the submission result
         return self.res_job_id

--- a/feathr_project/feathr/spark_provider/_synapse_submission.py
+++ b/feathr_project/feathr/spark_provider/_synapse_submission.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import json
 import os
 import pathlib
 import re
@@ -79,7 +80,7 @@ class _FeathrSynapseJobLauncher(SparkJobLauncher):
 
     def submit_feathr_job(self, job_name: str, main_jar_path: str = None,  main_class_name: str = None, arguments: List[str] = None,
                           python_files: List[str]= None, reference_files_path: List[str] = None, job_tags: Dict[str, str] = None,
-                          configuration: Dict[str, str] = {}):
+                          configuration: Dict[str, str] = {}, properties: Dict[str, str] = {}):
         """
         Submits the feathr job
         Refer to the Apache Livy doc for more details on the meaning of the parameters:
@@ -100,7 +101,11 @@ class _FeathrSynapseJobLauncher(SparkJobLauncher):
             arguments (str): all the arguments you want to pass into the spark job
             job_tags (str): tags of the job, for example you might want to put your user ID, or a tag with a certain information
             configuration (Dict[str, str]): Additional configs for the spark job
+            properties (Dict[str, str]): Additional System Properties for the spark job
         """
+
+        if properties:
+            arguments.append("--system-properties=%s" % json.dumps(properties))
 
         if configuration:
             cfg = configuration.copy()  # We don't want to mess up input parameters

--- a/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
@@ -39,7 +39,7 @@ class _PreprocessingPyudfManager(object):
         os.remove(client_udf_repo_path) if os.path.exists(client_udf_repo_path) else None
         for anchor in anchor_list:
             # only support batch source preprocessing for now.
-            if not isinstance(anchor.source, HdfsSource):
+            if not hasattr(anchor.source, "preprocessing"):
                 continue
             preprocessing_func = anchor.source.preprocessing
             if preprocessing_func:

--- a/feathr_project/test/test_sql_source.py
+++ b/feathr_project/test/test_sql_source.py
@@ -1,0 +1,141 @@
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from click.testing import CliRunner
+from feathr import BOOLEAN, FLOAT, INT32, ValueType
+from feathr import FeathrClient
+from feathr import JdbcSource
+from feathr import ValueType, Feature, FeatureAnchor, DerivedFeature, WindowAggTransformation, INPUT_CONTEXT
+from feathr.utils.job_utils import get_result_df
+from feathr import (BackfillTime, MaterializationSettings)
+from feathr import FeatureQuery
+from feathr import ObservationSettings
+from feathr import RedisSink, HdfsSink
+from feathr import TypedKey
+from feathrcli.cli import init
+import pytest
+
+from test_fixture import get_online_test_table_name
+
+def basic_test_setup(config_path: str):
+    """
+    Basically this is same as the one in `text_fixture.py` with the same name.
+    The difference is the `batch_source` is configured to read from JDBC instead of HDFS
+    """
+
+    client = FeathrClient(config_path=config_path)
+
+    # Using database under @windoze account, so this e2e test still doesn't work in CI
+    batch_source = JdbcSource(name="nycTaxiBatchJdbcSource",
+                              url="jdbc:sqlserver://feathrtestsql4.database.windows.net:1433;database=testsql;encrypt=true;trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30;",
+                              dbtable="green_tripdata_2020_04",
+                              auth="USERPASS",
+                              event_timestamp_column="lpep_dropoff_datetime",
+                              timestamp_format="yyyy-MM-dd HH:mm:ss")
+
+
+    f_trip_distance = Feature(name="f_trip_distance",
+                              feature_type=FLOAT, transform="trip_distance")
+    f_trip_time_duration = Feature(name="f_trip_time_duration",
+                                   feature_type=INT32,
+                                   transform="(to_unix_timestamp(lpep_dropoff_datetime) - to_unix_timestamp(lpep_pickup_datetime))/60")
+
+    features = [
+        f_trip_distance,
+        f_trip_time_duration,
+        Feature(name="f_is_long_trip_distance",
+                feature_type=BOOLEAN,
+                transform="cast_float(trip_distance)>30"),
+        Feature(name="f_day_of_week",
+                feature_type=INT32,
+                transform="dayofweek(lpep_dropoff_datetime)"),
+    ]
+
+
+    request_anchor = FeatureAnchor(name="request_features",
+                                   source=INPUT_CONTEXT,
+                                   features=features)
+
+    f_trip_time_distance = DerivedFeature(name="f_trip_time_distance",
+                                          feature_type=FLOAT,
+                                          input_features=[
+                                              f_trip_distance, f_trip_time_duration],
+                                          transform="f_trip_distance * f_trip_time_duration")
+
+    f_trip_time_rounded = DerivedFeature(name="f_trip_time_rounded",
+                                         feature_type=INT32,
+                                         input_features=[f_trip_time_duration],
+                                         transform="f_trip_time_duration % 10")
+
+    location_id = TypedKey(key_column="DOLocationID",
+                           key_column_type=ValueType.INT32,
+                           description="location id in NYC",
+                           full_name="nyc_taxi.location_id")
+    
+    # This feature is read from Jdbc data source
+    agg_features = [Feature(name="f_location_avg_fare",
+                            key=location_id,
+                            feature_type=FLOAT,
+                            transform=WindowAggTransformation(agg_expr="cast_float(fare_amount)",
+                                                              agg_func="AVG",
+                                                              window="90d")),
+                    ]
+
+    agg_anchor = FeatureAnchor(name="aggregationFeatures",
+                               source=batch_source,
+                               features=agg_features)
+
+    client.build_features(anchor_list=[agg_anchor, request_anchor], derived_feature_list=[
+        f_trip_time_distance, f_trip_time_rounded])
+
+    return client
+
+@pytest.mark.skip(reason="Requires database with test data imported, which doesn't exist in the current CI env")
+def test_feathr_get_offline_features():
+    """
+    Test FeathrClient() get_offline_features works with Jdbc data source.
+    Currently it doesn't work in CI env hence being marked as `skip`,
+    because it requires a database with `green_tripdata_2020-04.csv` imported into a table named `green_tripdata_2020_04`.
+    To run this test, you'll also need following environment variables set correctly:
+    - nycTaxiBatchJdbcSource_USER: The user name to login to database server
+    - nycTaxiBatchJdbcSource_PASSWORD: The password to login to database server
+    These 2 variables will be passed to the Spark job in `--system-properties` parameter so Spark can access the database
+    """
+
+    online_test_table = get_online_test_table_name("nycTaxiCITable")
+    test_workspace_dir = Path(
+        __file__).parent.resolve() / "test_user_workspace"
+    # os.chdir(test_workspace_dir)
+
+    client = basic_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
+
+    location_id = TypedKey(key_column="DOLocationID",
+                            key_column_type=ValueType.INT32,
+                            description="location id in NYC",
+                            full_name="nyc_taxi.location_id")
+
+    feature_query = FeatureQuery(
+        feature_list=["f_location_avg_fare"], key=location_id)
+    settings = ObservationSettings(
+        observation_path="wasbs://public@azurefeathrstorage.blob.core.windows.net/sample_data/green_tripdata_2020-04.csv",
+        event_timestamp_column="lpep_dropoff_datetime",
+        timestamp_format="yyyy-MM-dd HH:mm:ss")
+
+    now = datetime.now()
+    output_path = ''.join(['dbfs:/feathrazure_cijob','_', str(now.minute), '_', str(now.second), ".avro"])
+    
+    client.get_offline_features(observation_settings=settings,
+                                feature_query=feature_query,
+                                output_path=output_path)
+
+    # assuming the job can successfully run; otherwise it will throw exception
+    client.wait_job_to_finish(timeout_sec=900)
+
+    # download result and just assert the returned result is not empty
+    res_df = get_result_df(client)
+    assert res_df.shape[0] > 0
+
+    
+if __name__ == "__main__":
+    test_feathr_get_offline_features()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.6.2

--- a/src/main/java/com/linkedin/feathr/common/util/MvelContextUDFs.java
+++ b/src/main/java/com/linkedin/feathr/common/util/MvelContextUDFs.java
@@ -70,7 +70,9 @@ public class MvelContextUDFs {
 
   /**
    * Cast the input to double.
-   * If it's null, null is returned. If it's string, it will try to parse it. For other types, it will be coerced to double.
+   * If it's null, null is returned. If it's string, it will try to parse it.
+   * For number types, it will do standard conversion.
+   * For other types, it will be coerced to double.
    *
    */
   @ExportToMvel
@@ -80,6 +82,8 @@ public class MvelContextUDFs {
     }
     if (input instanceof String) {
       return Double.parseDouble((String)input);
+    } else if (input instanceof Number) {
+      return ((Number)input).doubleValue();
     } else {
       return (Double)input;
     }
@@ -87,7 +91,9 @@ public class MvelContextUDFs {
 
   /**
    * Cast the input to float.
-   * If it's null, null is returned. If it's string, it will try to parse it. For other types, it will be coerced to float.
+   * If it's null, null is returned. If it's string, it will try to parse it.
+   * For number types, it will do standard conversion.
+   * For other types, it will be coerced to float.
    *
    */
   @ExportToMvel
@@ -97,6 +103,8 @@ public class MvelContextUDFs {
     }
     if (input instanceof String) {
       return Float.parseFloat((String)input);
+    } else if (input instanceof Number) {
+      return ((Number)input).floatValue();
     } else {
       return (Float)input;
     }
@@ -104,7 +112,9 @@ public class MvelContextUDFs {
 
   /**
    * Cast the input to Integer.
-   * If it's null, null is returned. If it's string, it will try to parse it. For other types, it will be coerced to Integer.
+   * If it's null, null is returned. If it's string, it will try to parse it.
+   * For number types, it will do standard conversion.
+   * For other types, it will be coerced to Integer.
    *
    */
   @ExportToMvel
@@ -114,6 +124,8 @@ public class MvelContextUDFs {
     }
     if (input instanceof String) {
       return Integer.parseInt((String)input);
+    } else if (input instanceof Number) {
+      return ((Number)input).intValue();
     } else {
       return (Integer)input;
     }

--- a/src/main/scala/com/linkedin/feathr/offline/config/FeathrConfigLoader.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/FeathrConfigLoader.scala
@@ -13,7 +13,7 @@ import com.linkedin.feathr.offline.ErasedEntityTaggedFeature
 import com.linkedin.feathr.offline.anchored.anchorExtractor.{SQLConfigurableAnchorExtractor, SimpleConfigurableAnchorExtractor, TimeWindowConfigurableAnchorExtractor}
 import com.linkedin.feathr.offline.anchored.feature.{FeatureAnchor, FeatureAnchorWithSource}
 import com.linkedin.feathr.offline.anchored.keyExtractor.{MVELSourceKeyExtractor, SQLSourceKeyExtractor}
-import com.linkedin.feathr.offline.config.location.{InputLocation, KafkaEndpoint, LocationUtils, SimplePath}
+import com.linkedin.feathr.offline.config.location.{InputLocation, Jdbc, KafkaEndpoint, LocationUtils, SimplePath}
 import com.linkedin.feathr.offline.derived._
 import com.linkedin.feathr.offline.derived.functions.{MvelFeatureDerivationFunction, SQLFeatureDerivationFunction, SeqJoinDerivationFunction, SimpleMvelDerivationFunction}
 import com.linkedin.feathr.offline.source.{DataSource, SourceFormatType, TimeWindowParams}
@@ -713,15 +713,6 @@ private[offline] class DataSourceLoader extends JsonDeserializer[DataSource] {
      *    since anchor defined pass-through features do not have path
      */
     val path: InputLocation = dataSourceType match {
-      case "HDFS" =>
-        Option(node.get("location")) match {
-          case Some(field: ObjectNode) =>
-            LocationUtils.getMapper().treeToValue(field, classOf[InputLocation])
-          case None => throw new FeathrConfigException(ErrorLabel.FEATHR_USER_ERROR,
-                                s"Data location is not defined for HDFS source ${node.toPrettyString()}")
-          case _ => throw new FeathrConfigException(ErrorLabel.FEATHR_USER_ERROR,
-                                s"Illegal setting for location for HDFS source ${node.toPrettyString()}, expected map")
-        }
       case "KAFKA" =>
         Option(node.get("config")) match {
           case Some(field: ObjectNode) =>
@@ -731,8 +722,16 @@ private[offline] class DataSourceLoader extends JsonDeserializer[DataSource] {
           case _ => throw new FeathrConfigException(ErrorLabel.FEATHR_USER_ERROR,
                                 s"Illegal setting for Kafka source ${node.toPrettyString()}, expected map")
         }
-      case _ => SimplePath("PASSTHROUGH")
+      case _ => Option(node.get("location")) match {
+        case Some(field: ObjectNode) =>
+          LocationUtils.getMapper().treeToValue(field, classOf[InputLocation])
+        case None => throw new FeathrConfigException(ErrorLabel.FEATHR_USER_ERROR,
+          s"Data location is not defined for data source ${node.toPrettyString()}")
+        case _ => throw new FeathrConfigException(ErrorLabel.FEATHR_USER_ERROR,
+          s"Illegal setting for location for data source ${node.toPrettyString()}, expected map")
+      }
     }
+    println(s"Source location is: $path")
 
     // time window parameters for data aggregation
     val timeWindowParameterNode = Option(node.get("timeWindowParameters")) match {

--- a/src/main/scala/com/linkedin/feathr/offline/config/FeathrConfigLoader.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/FeathrConfigLoader.scala
@@ -722,6 +722,7 @@ private[offline] class DataSourceLoader extends JsonDeserializer[DataSource] {
           case _ => throw new FeathrConfigException(ErrorLabel.FEATHR_USER_ERROR,
                                 s"Illegal setting for Kafka source ${node.toPrettyString()}, expected map")
         }
+      case "PASSTHROUGH" => SimplePath("PASSTHROUGH")
       case _ => Option(node.get("location")) match {
         case Some(field: ObjectNode) =>
           LocationUtils.getMapper().treeToValue(field, classOf[InputLocation])

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/InputLocation.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/InputLocation.scala
@@ -42,6 +42,12 @@ trait InputLocation {
    */
   def loadDf(ss: SparkSession, dataIOParameters: Map[String, String] = Map()): DataFrame
 
+  /**
+   * Tell if this location is file based
+   * @return boolean
+   */
+  def isFileBasedLocation(): Boolean
+
   override def toString: String = getPath
 }
 

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/InputLocation.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/InputLocation.scala
@@ -26,13 +26,21 @@ trait InputLocation {
    * Backward Compatibility
    * Many existing codes expect a simple path
    * @return the `path` or `url` of the data source
+   *
+   * WARN: This method is deprecated, you must use match/case on InputLocation,
+   * and get `path` from `SimplePath` only
    */
+  @deprecated("Do not use this method in any new code, it will be removed soon")
   def getPath: String
 
   /**
    * Backward Compatibility
    * @return the `path` or `url` of the data source, wrapped in an List
+   *
+   * WARN: This method is deprecated, you must use match/case on InputLocation,
+   * and get `paths` from `PathList` only
    */
+  @deprecated("Do not use this method in any new code, it will be removed soon")
   def getPathList: List[String]
 
   /**

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/Jdbc.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/Jdbc.scala
@@ -48,6 +48,10 @@ case class Jdbc(url: String, @JsonAlias(Array("query")) dbtable: String, user: S
   override def getPath: String = url
 
   override def getPathList: List[String] = List(url)
+
+  override def isFileBasedLocation(): Boolean = false
+
+  override def toString: String = s"Jdbc(url=$url, dbtable=$dbtable, useToken=$useToken, anonymous=$anonymous)"
 }
 
 object Jdbc {

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/Jdbc.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/Jdbc.scala
@@ -10,6 +10,7 @@ import org.eclipse.jetty.util.StringUtil
 @CaseClassDeserialize()
 case class Jdbc(url: String, @JsonAlias(Array("query")) dbtable: String, user: String = "", password: String = "", token: String = "", useToken: Boolean = false, anonymous: Boolean = false) extends InputLocation {
   override def loadDf(ss: SparkSession, dataIOParameters: Map[String, String] = Map()): DataFrame = {
+    println(s"Jdbc.loadDf, location is ${this}")
     var reader = ss.read.format("jdbc")
       .option("url", url)
     if (StringUtil.isBlank(dbtable)) {
@@ -35,6 +36,7 @@ case class Jdbc(url: String, @JsonAlias(Array("query")) dbtable: String, user: S
           reader.load()
         } else {
           // Fallback to global JDBC credential
+          println("Fallback to default credential")
           ss.conf.set(DBTABLE_CONF, dbtable)
           JdbcUtils.loadDataFrame(ss, url)
         }
@@ -51,7 +53,8 @@ case class Jdbc(url: String, @JsonAlias(Array("query")) dbtable: String, user: S
 
   override def isFileBasedLocation(): Boolean = false
 
-  override def toString: String = s"Jdbc(url=$url, dbtable=$dbtable, useToken=$useToken, anonymous=$anonymous)"
+  // These members don't contain actual secrets
+  override def toString: String = s"Jdbc(url=$url, dbtable=$dbtable, useToken=$useToken, anonymous=$anonymous, user=$user, password=$password, token=$token)"
 }
 
 object Jdbc {

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/KafkaEndpoint.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/KafkaEndpoint.scala
@@ -34,6 +34,8 @@ case class KafkaEndpoint(@JsonProperty("brokers") brokers: List[String],
   override def getPath: String = "kafka://" + brokers.mkString(",")+":"+topics.mkString(",")
 
   override def getPathList: List[String] = ???
+
+  override def isFileBasedLocation(): Boolean = false
 }
 
 

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/PathList.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/PathList.scala
@@ -9,6 +9,8 @@ case class PathList(paths: List[String]) extends InputLocation {
 
   override def getPathList: List[String] = paths
 
+  override def isFileBasedLocation(): Boolean = true
+
   override def loadDf(ss: SparkSession, dataIOParameters: Map[String, String] = Map()): DataFrame = {
     SparkIOUtils.createUnionDataFrame(getPathList, dataIOParameters, new JobConf(), List()) //TODO: Add handler support here. Currently there are deserilization issues with adding handlers to factory builder.
   }

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/PathList.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/PathList.scala
@@ -14,6 +14,8 @@ case class PathList(paths: List[String]) extends InputLocation {
   override def loadDf(ss: SparkSession, dataIOParameters: Map[String, String] = Map()): DataFrame = {
     SparkIOUtils.createUnionDataFrame(getPathList, dataIOParameters, new JobConf(), List()) //TODO: Add handler support here. Currently there are deserilization issues with adding handlers to factory builder.
   }
+
+  override def toString: String = s"PathList(path=[${paths.mkString(",")}])"
 }
 
 object PathList {

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/SimplePath.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/SimplePath.scala
@@ -17,4 +17,6 @@ case class SimplePath(@JsonProperty("path") path: String) extends InputLocation 
   override def getPathList: List[String] = List(path)
 
   override def isFileBasedLocation(): Boolean = true
+
+  override def toString: String = s"SimplePath(path=${path})"
 }

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/SimplePath.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/SimplePath.scala
@@ -15,4 +15,6 @@ case class SimplePath(@JsonProperty("path") path: String) extends InputLocation 
   override def getPath: String = path
 
   override def getPathList: List[String] = List(path)
+
+  override def isFileBasedLocation(): Boolean = true
 }

--- a/src/main/scala/com/linkedin/feathr/offline/job/FeatureGenJob.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/job/FeatureGenJob.scala
@@ -1,5 +1,7 @@
 package com.linkedin.feathr.offline.job
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.linkedin.feathr.common.TaggedFeatureName
 import com.linkedin.feathr.common.configObj.configbuilder.FeatureGenConfigBuilder
 import com.linkedin.feathr.offline.client.FeathrClient
@@ -18,6 +20,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 object FeatureGenJob {
 
@@ -48,11 +51,17 @@ object FeatureGenJob {
       "sql-config" -> OptionParam("sqlc", "Authentication config for Azure SQL Database (jdbc)", "SQL_CONFIG", ""),
       "snowflake-config" -> OptionParam("sfc", "Authentication config for Snowflake Database (jdbc)", "SNOWFLAKE_CONFIG", ""),
       "monitoring-config" -> OptionParam("mc", "Feature monitoring related configs", "MONITORING_CONFIG", ""),
-      "kafka-config" -> OptionParam("kc", "Authentication config for Kafka", "KAFKA_CONFIG", "")
+      "kafka-config" -> OptionParam("kc", "Authentication config for Kafka", "KAFKA_CONFIG", ""),
+      "system-properties" -> OptionParam("sps", "Additional System Properties", "SYSTEM_PROPERTIES_CONFIG", "")
     )
     val extraOptions = List(new CmdOption("LOCALMODE", "local-mode", false, "Run in local mode"))
 
     val cmdParser = new CmdLineParser(args, params, extraOptions)
+
+    // Set system properties passed via arguments
+    val sps = cmdParser.extractOptionalValue("system-properties").getOrElse("{}")
+    val props = (new ObjectMapper()).registerModule(DefaultScalaModule).readValue(sps, classOf[mutable.HashMap[String, String]])
+    props.foreach(e => scala.util.Properties.setProp(e._1, e._2))
 
     val applicationConfigPath = cmdParser.extractRequiredValue("generation-config")
     val featureDefinitionsInput = new FeatureDefinitionsInput(

--- a/src/main/scala/com/linkedin/feathr/offline/job/FeatureJoinJob.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/job/FeatureJoinJob.scala
@@ -1,5 +1,7 @@
 package com.linkedin.feathr.offline.job
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.linkedin.feathr.common
 import com.linkedin.feathr.common.exception.{ErrorLabel, FeathrDataOutputException, FeathrInputDataException}
 import com.linkedin.feathr.common.{Header, JoiningFeatureParams}
@@ -26,6 +28,7 @@ import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success}
 import collection.JavaConverters._
+import scala.collection.mutable
 
 /**
  * Join features to some observations for training/testing
@@ -219,12 +222,18 @@ object FeatureJoinJob {
       "adls-config" -> OptionParam("adlc", "Authentication config for ADLS (abfs)", "ADLS_CONFIG", ""),
       "blob-config" -> OptionParam("bc", "Authentication config for Azure Blob Storage (wasb)", "BLOB_CONFIG", ""),
       "sql-config" -> OptionParam("sqlc", "Authentication config for Azure SQL Database (jdbc)", "SQL_CONFIG", ""),
-      "snowflake-config" -> OptionParam("sfc", "Authentication config for Snowflake Database (jdbc)", "SNOWFLAKE_CONFIG", "")
+      "snowflake-config" -> OptionParam("sfc", "Authentication config for Snowflake Database (jdbc)", "SNOWFLAKE_CONFIG", ""),
+      "system-properties" -> OptionParam("sps", "Additional System Properties", "SYSTEM_PROPERTIES_CONFIG", "")
     )
 
     val extraOptions = List(new CmdOption("LOCALMODE", "local-mode", false, "Run in local mode"))
 
     val cmdParser = new CmdLineParser(args, params, extraOptions)
+
+    // Set system properties passed via arguments
+    val sps = cmdParser.extractOptionalValue("system-properties").getOrElse("{}")
+    val props = (new ObjectMapper()).registerModule(DefaultScalaModule).readValue(sps, classOf[mutable.HashMap[String, String]])
+    props.foreach(e => scala.util.Properties.setProp(e._1, e._2))
 
     val joinConfig = cmdParser.extractRequiredValue("join-config")
 

--- a/src/main/scala/com/linkedin/feathr/offline/source/accessor/DataSourceAccessor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/accessor/DataSourceAccessor.scala
@@ -57,7 +57,7 @@ private[offline] object DataSourceAccessor {
     val dataLoaderFactory = DataLoaderFactory(ss, isStreaming, dataLoaderHandlers)
     if (isStreaming) {
       new StreamDataSourceAccessor(ss, dataLoaderFactory, source)
-    } else if (dateIntervalOpt.isEmpty || sourceType == SourceFormatType.FIXED_PATH || sourceType == SourceFormatType.LIST_PATH) {
+    } else if (dateIntervalOpt.isEmpty || source.location.isFileBasedLocation()) {
       // if no input interval, or the path is fixed or list, load whole dataset
       new NonTimeBasedDataSourceAccessor(ss, dataLoaderFactory, source, expectDatumType)
     } else {

--- a/src/main/scala/com/linkedin/feathr/offline/source/accessor/DataSourceAccessor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/accessor/DataSourceAccessor.scala
@@ -57,7 +57,7 @@ private[offline] object DataSourceAccessor {
     val dataLoaderFactory = DataLoaderFactory(ss, isStreaming, dataLoaderHandlers)
     if (isStreaming) {
       new StreamDataSourceAccessor(ss, dataLoaderFactory, source)
-    } else if (dateIntervalOpt.isEmpty || source.location.isFileBasedLocation()) {
+    } else if (dateIntervalOpt.isEmpty || sourceType == SourceFormatType.FIXED_PATH || sourceType == SourceFormatType.LIST_PATH) {
       // if no input interval, or the path is fixed or list, load whole dataset
       new NonTimeBasedDataSourceAccessor(ss, dataLoaderFactory, source, expectDatumType)
     } else {

--- a/src/main/scala/com/linkedin/feathr/offline/source/accessor/NonTimeBasedDataSourceAccessor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/accessor/NonTimeBasedDataSourceAccessor.scala
@@ -1,6 +1,6 @@
 package com.linkedin.feathr.offline.source.accessor
 
-import com.linkedin.feathr.offline.config.location.KafkaEndpoint
+import com.linkedin.feathr.offline.config.location.{Jdbc, KafkaEndpoint}
 import com.linkedin.feathr.offline.source.DataSource
 import com.linkedin.feathr.offline.source.dataloader.DataLoaderFactory
 import com.linkedin.feathr.offline.testfwk.TestFwkUtils
@@ -29,7 +29,8 @@ private[offline] class NonTimeBasedDataSourceAccessor(
     val df = if (source.location.isInstanceOf[KafkaEndpoint]) {
      fileLoaderFactory.createFromLocation(source.location).loadDataFrame()
     } else {
-      source.pathList.map(fileLoaderFactory.create(_).loadDataFrame()).reduce((x, y) => x.fuzzyUnion(y))
+      println(s"NonTimeBasedDataSourceAccessor loading source ${source.location}")
+      source.location.loadDf(ss)
     }
     if (TestFwkUtils.IS_DEBUGGER_ENABLED) {
       println()

--- a/src/main/scala/com/linkedin/feathr/offline/source/accessor/NonTimeBasedDataSourceAccessor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/accessor/NonTimeBasedDataSourceAccessor.scala
@@ -30,6 +30,7 @@ private[offline] class NonTimeBasedDataSourceAccessor(
     val df = source.location match {
       case SimplePath(path) => List(path).map(fileLoaderFactory.create(_).loadDataFrame()).reduce((x, y) => x.fuzzyUnion(y))
       case PathList(paths) => paths.map(fileLoaderFactory.create(_).loadDataFrame()).reduce((x, y) => x.fuzzyUnion(y))
+      case Jdbc(_, _, _, _, _, _, _) => source.location.loadDf(SparkSession.builder().getOrCreate())
       case _ => fileLoaderFactory.createFromLocation(source.location).loadDataFrame()
     }
 

--- a/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
@@ -63,16 +63,17 @@ private[offline] class BatchDataLoader(ss: SparkSession, location: InputLocation
     val dataIOParametersWithSplitSize = Map(SparkIOUtils.SPLIT_SIZE -> inputSplitSize) ++ dataIOParameters
     val dataPath = location.getPath
 
-    log.info(s"Loading ${dataPath} as DataFrame, using parameters ${dataIOParametersWithSplitSize}")
+    log.info(s"Loading ${location} as DataFrame, using parameters ${dataIOParametersWithSplitSize}")
     try {
-      if (dataPath.startsWith("jdbc")){
-        JdbcUtils.loadDataFrame(ss, dataPath)
-      } else {
+//      if (dataPath.startsWith("jdbc")){
+//        location.loadDf(ss, dataIOParametersWithSplitSize)
+//      } else {
         import scala.util.control.Breaks._
 
         var dfOpt: Option[DataFrame] = None
         breakable {
           for(dataLoaderHandler <- dataLoaderHandlers) {
+            println(s"Applying dataLoaderHandler ${dataLoaderHandler}")
             if (dataLoaderHandler.validatePath(dataPath)) {
               dfOpt = Some(dataLoaderHandler.createDataFrame(dataPath, dataIOParametersWithSplitSize, jobConf))
               break
@@ -84,12 +85,14 @@ private[offline] class BatchDataLoader(ss: SparkSession, location: InputLocation
           case _ => location.loadDf(ss, dataIOParametersWithSplitSize)
         }
         df
-      }
+//      }
     } catch {
-      case feathrException: FeathrInputDataException => 
+      case feathrException: FeathrInputDataException =>
+        println(feathrException.toString)
         throw feathrException // Throwing exception to avoid dataLoaderHandler hook exception from being swallowed.
-      case e: Throwable => //TODO: Analyze all thrown exceptions, instead of swalling them all, and reading as a csv
-        ss.read.format("csv").option("header", "true").load(dataPath)
+//      case e: Throwable => //TODO: Analyze all thrown exceptions, instead of swalling them all, and reading as a csv
+//        println(e.toString)
+//        ss.read.format("csv").option("header", "true").load(dataPath)
     }
   }
 }

--- a/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/dataloader/BatchDataLoader.scala
@@ -65,9 +65,6 @@ private[offline] class BatchDataLoader(ss: SparkSession, location: InputLocation
 
     log.info(s"Loading ${location} as DataFrame, using parameters ${dataIOParametersWithSplitSize}")
     try {
-//      if (dataPath.startsWith("jdbc")){
-//        location.loadDf(ss, dataIOParametersWithSplitSize)
-//      } else {
         import scala.util.control.Breaks._
 
         var dfOpt: Option[DataFrame] = None
@@ -85,14 +82,13 @@ private[offline] class BatchDataLoader(ss: SparkSession, location: InputLocation
           case _ => location.loadDf(ss, dataIOParametersWithSplitSize)
         }
         df
-//      }
     } catch {
       case feathrException: FeathrInputDataException =>
         println(feathrException.toString)
         throw feathrException // Throwing exception to avoid dataLoaderHandler hook exception from being swallowed.
-//      case e: Throwable => //TODO: Analyze all thrown exceptions, instead of swalling them all, and reading as a csv
-//        println(e.toString)
-//        ss.read.format("csv").option("header", "true").load(dataPath)
+      case e: Throwable => //TODO: Analyze all thrown exceptions, instead of swalling them all, and reading as a csv
+        println(e.toString)
+        ss.read.format("csv").option("header", "true").load(dataPath)
     }
   }
 }

--- a/src/main/scala/com/linkedin/feathr/offline/source/dataloader/hdfs/FileFormat.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/dataloader/hdfs/FileFormat.scala
@@ -93,7 +93,7 @@ object FileFormat {
         ss.read.format(PARQUET).load(existingHdfsPaths: _*)
       case _ =>
         // Allow dynamic config of the file format if users want to use one
-        if (ss.conf.get("spark.feathr.inputFormat").nonEmpty) ss.read.format(ss.conf.get("spark.feathr.inputFormat")).load(existingHdfsPaths: _*)
+        if (ss.conf.getOption("spark.feathr.inputFormat").nonEmpty) ss.read.format(ss.conf.get("spark.feathr.inputFormat")).load(existingHdfsPaths: _*)
         else throw new FeathrException(s"Unsupported data format $format and 'spark.feathr.inputFormat' not set.")
     }
     df

--- a/src/main/scala/com/linkedin/feathr/offline/source/dataloader/hdfs/FileFormat.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/source/dataloader/hdfs/FileFormat.scala
@@ -2,6 +2,7 @@ package com.linkedin.feathr.offline.source.dataloader.hdfs
 
 import com.linkedin.feathr.common.exception.FeathrException
 import com.linkedin.feathr.offline.source.dataloader._
+import com.linkedin.feathr.offline.source.dataloader.jdbc.JdbcUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.DataFrame
 
@@ -91,6 +92,9 @@ object FileFormat {
         ss.read.format(ORC_DATASOURCE).load(existingHdfsPaths: _*)
       case PARQUET =>
         ss.read.format(PARQUET).load(existingHdfsPaths: _*)
+      case JDBC =>
+        // TODO: We should stop using JDBC URL as simple path, otherwise the code will be full of such hack
+        JdbcUtils.loadDataFrame(ss, existingHdfsPaths.head)
       case _ =>
         // Allow dynamic config of the file format if users want to use one
         if (ss.conf.getOption("spark.feathr.inputFormat").nonEmpty) ss.read.format(ss.conf.get("spark.feathr.inputFormat")).load(existingHdfsPaths: _*)

--- a/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/transformation/AnchorToDataSourceMapper.scala
@@ -4,6 +4,7 @@ import java.time.Duration
 import com.linkedin.feathr.common.{DateParam, DateTimeResolution}
 import com.linkedin.feathr.offline.source.SourceFormatType._
 import com.linkedin.feathr.offline.anchored.feature.FeatureAnchorWithSource
+import com.linkedin.feathr.offline.config.location.{PathList, SimplePath}
 import com.linkedin.feathr.offline.generation.IncrementalAggContext
 import com.linkedin.feathr.offline.source.DataSource
 import com.linkedin.feathr.offline.source.accessor.DataSourceAccessor
@@ -93,13 +94,19 @@ private[offline] class AnchorToDataSourceMapper(dataPathHandlers: List[DataPathH
       failOnMissingPartition: Boolean): DataFrame = {
 
     val dataLoaderHandlers: List[DataLoaderHandler] = dataPathHandlers.map(_.dataLoaderHandler)
-    val pathChecker = PathChecker(ss)
-    val pathAnalyzer = new TimeBasedHdfsPathAnalyzer(pathChecker, dataLoaderHandlers)
-    val pathInfo = pathAnalyzer.analyze(factDataSource.path)
-    val adjustedObsTimeRange = if (pathInfo.dateTimeResolution == DateTimeResolution.DAILY)
-    {
-      obsTimeRange.adjustWithDateTimeResolution(DateTimeResolution.DAILY)
-    } else obsTimeRange
+
+    // Only file-based source has real "path", others are just single dataset
+    val adjustedObsTimeRange = if (factDataSource.location.isFileBasedLocation()) {
+      val pathChecker = PathChecker(ss)
+      val pathAnalyzer = new TimeBasedHdfsPathAnalyzer(pathChecker, dataLoaderHandlers)
+      val pathInfo = pathAnalyzer.analyze(factDataSource.path)
+      if (pathInfo.dateTimeResolution == DateTimeResolution.DAILY)
+      {
+        obsTimeRange.adjustWithDateTimeResolution(DateTimeResolution.DAILY)
+      } else obsTimeRange
+    } else {
+      obsTimeRange
+    }
 
     val timeInterval = OfflineDateTimeUtils.getFactDataTimeRange(adjustedObsTimeRange, window, timeDelays)
     val needCreateTimestampColumn = SlidingWindowFeatureUtils.needCreateTimestampColumnFromPartition(factDataSource)

--- a/src/test/scala/com/linkedin/feathr/offline/config/TestDataSourceLoader.scala
+++ b/src/test/scala/com/linkedin/feathr/offline/config/TestDataSourceLoader.scala
@@ -2,11 +2,14 @@ package com.linkedin.feathr.offline.config
 
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.jasonclawson.jackson.dataformat.hocon.HoconFactory
 import com.linkedin.feathr.common.FeathrJacksonScalaModule
 import com.linkedin.feathr.offline.config.location.{Jdbc, LocationUtils}
 import com.linkedin.feathr.offline.source.{DataSource, SourceFormatType}
 import org.scalatest.FunSuite
+
+import scala.collection.mutable
 
 
 class TestDataSourceLoader extends FunSuite {
@@ -58,5 +61,15 @@ class TestDataSourceLoader extends FunSuite {
       }
       case _ => assert(false)
     }
+    assert(ds.timeWindowParams.nonEmpty)
+    assert(ds.timePartitionPattern.isEmpty)
+    assert(ds.timeWindowParams.get.timestampColumn=="lpep_dropoff_datetime")
+    assert(ds.timeWindowParams.get.timestampColumnFormat=="yyyy-MM-dd HH:mm:ss")
+  }
+
+  test("test SWA with dense vector feature") {
+    val sps = """{"nycTaxiBatchJdbcSource_USER": "user@host", "nycTaxiBatchJdbcSource_PASSWORD": "magic-word"}"""
+    val props = (new ObjectMapper()).registerModule(DefaultScalaModule).readValue(sps, classOf[mutable.HashMap[String, String]])
+    assert(props.get("nycTaxiBatchJdbcSource_PASSWORD")==Some("magic-word"))
   }
 }


### PR DESCRIPTION
This is the refreshed PR for #124, the old one was stale for too long and cannot be cleanly merged.
This PR does following things:

1. Add a `--system-properties` command line parameter to the Spark job, so the client can pass multiple secrets to the job.
2. The reading from JDBC function already exists in the job code but doesn't have public interface to use, now this function is enabled when you have JdbcSource in the feature definition file.
3. On the client side, a `JdbcSource` is added to represent a data source from JDBC, with auth, and corresponding data model change.
4. Various fixes to both job and client sides.
5. An E2E test to get offline features from JDBC data source.

Currently the E2E test cannot run in the CI env because it requires a database with `green_tripdata_2020-04.csv` imported into a table called `green_tripdata_2020_04`, with auth configured correctly.

To run the E2E test locally, you need:

- Create a SQL database instance with user/pass auth on Azure, AAD/token auth is not covered by this test.
- Import `green_tripdata_2020-04.csv` into the database with the table name set to `green_tripdata_2020_04`, be aware of the column type, all numeric columns like prices or distances must be "FLOAT" and all ID columns must be "INT" if you're using AzureSQL.
- Set following environment variables
    - `nycTaxiBatchJdbcSource_USER`: The user name to login to database server
    - `nycTaxiBatchJdbcSource_PASSWORD`: The password to login to database server

Then you should be able to run the `test_sql_source.py` directly or via `pytest`, both Databricks and Azure Synapse should work. You can use whatever user/pass combination for each Jdbc data source, not limited to the previously global unique `JDBC_*` settings.