### PR TITLE
Feathr UI: fit lineage graph to center of layout view on page load

### DIFF
--- a/ui/src/components/graph/graph.tsx
+++ b/ui/src/components/graph/graph.tsx
@@ -9,6 +9,7 @@ import ReactFlow, {
   isEdge,
   isNode,
   Node,
+  OnLoadParams,
   ReactFlowProvider
 } from 'react-flow-renderer';
 import { useSearchParams } from 'react-router-dom';
@@ -120,7 +121,12 @@ const Graph: React.FC<Props> = ({ data, nodeId }) => {
     }
   }, [nodeId]);
 
-  // When panel is clicked, reset all highlighted path, and remove the nodeId query string in url path.
+  // Fit the graph to the center of layout view when graph is initialized
+  const onLoad = (reactFlowInstance: OnLoadParams<unknown> | null) => {
+    reactFlowInstance?.fitView();
+  };
+
+  // Fired when panel is clicked, reset all highlighted path, and remove the nodeId query string in url path.
   const onPaneClick = useCallback(() => {
     resetHighlight();
     setURLSearchParams({});
@@ -145,6 +151,7 @@ const Graph: React.FC<Props> = ({ data, nodeId }) => {
             snapToGrid
             snapGrid={ [15, 15] }
             zoomOnScroll={ false }
+            onLoad={onLoad}
             onPaneClick={ onPaneClick }
             onElementClick={ (_: ReactMouseEvent, element: Node | Edge): void => {
               if (isNode(element)) {

--- a/ui/src/components/graph/graphNodeDetails.tsx
+++ b/ui/src/components/graph/graphNodeDetails.tsx
@@ -18,7 +18,7 @@ const GraphNodeDetails: React.FC = () => {
   const [feature, setFeature] = useState<Feature>();
   const [loading, setLoading] = useState<boolean>(false);
 
-  const isFeature = (featureType:string) => {
+  const isFeature = (featureType: string) => {
     return featureType === 'feathr_anchor_feature_v1' || featureType === 'feathr_derived_feature_v1'
   }
 
@@ -42,6 +42,7 @@ const GraphNodeDetails: React.FC = () => {
         loading
           ? (<Spin indicator={ <LoadingOutlined style={ { fontSize: 24 } } spin /> } />)
           : (<div style={ { margin: "2%" } }>
+            { !feature && <p>Click on node to show metadata and metric details</p> }
             { feature?.attributes.transformation &&
                 <Card title="Transformation">
                   { feature.attributes.transformation.transform_expr &&


### PR DESCRIPTION
This PR make lineage graph figs to center of layout view automatically when page loads.

Linked issue: #272 