### PR TITLE
Fix docs readme broken links and aligned with GitHub readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,6 @@ Feathr automatically computes your feature values and joins them to your trainin
 - **Native cloud integration** with simplified and scalable architecture, which is illustrated in the next section.
 - **Feature sharing and reuse made easy:** Feathr has built-in feature registry so that features can be easily shared across different teams and boost team productivity.
 
-
 ## Running Feathr on Azure with 3 Simple Steps
 
 Feathr has native cloud integration. To use Feathr on Azure, you only need three steps:
@@ -50,7 +49,7 @@ Feathr has native cloud integration. To use Feathr on Azure, you only need three
 If you are not using the above Jupyter Notebook and want to install Feathr client locally, use this:
 
 ```bash
-pip install -U feathr
+pip install feathr
 ```
 
 Or use the latest code from GitHub:
@@ -126,31 +125,30 @@ Read the [Streaming Source Ingestion Guide](https://linkedin.github.io/feathr/ho
 
 Read [Point-in-time Correctness and Point-in-time Join in Feathr](https://linkedin.github.io/feathr/concepts/point-in-time-join.html) for more details.
 
-
 ## Running Feathr Examples
 
-Follow the [quick start Jupyter Notebook](./feathr_project/feathrcli/data/feathr_user_workspace/product_recommendation_demo.ipynb) to try it out. There is also a companion [quick start guide](https://linkedin.github.io/feathr/quickstart.html) containing a bit more explanation on the notebook.
-
+Follow the [quick start Jupyter Notebook](https://github.com/linkedin/feathr/blob/main/feathr_project/feathrcli/data/feathr_user_workspace/product_recommendation_demo.ipynb) to try it out.
+There is also a companion [quick start guide](https://linkedin.github.io/feathr/quickstart_synapse.html) containing a bit more explanation on the notebook.
 
 ## Cloud Architecture
 
 Feathr has native integration with Azure and other cloud services, and here's the high-level architecture to help you get started.
 ![Architecture](images/architecture.png)
 
-# Next Steps
+## Next Steps
 
-## Quickstart
+### Quickstart
 
 - [Quickstart for Azure Synapse](quickstart_synapse.md)
 
-## Concepts
+### Concepts
 
 - [Feature Definition](concepts/feature-definition.md)
 - [Feature Generation](concepts/feature-generation.md)
 - [Feature Join](concepts/feature-join.md)
 - [Point-in-time Correctness](concepts/point-in-time-join.md)
 
-## How-to-guides
+### How-to-guides
 
 - [Azure Deployment](how-to-guides/azure-deployment.md)
 - [Local Feature Testing](how-to-guides/local-feature-testing.md)
@@ -159,4 +157,5 @@ Feathr has native integration with Azure and other cloud services, and here's th
 - [Feathr Job Configuration](how-to-guides/feathr-job-configuration.md)
 
 ## API Documentation
+
 - [Python API Documentation](https://feathr.readthedocs.io/en/latest/)


### PR DESCRIPTION
Background: the broken links are fixed in GitHub readme; however, the same contents are in docs readme and is broken too. 

Included in this PR:
- fix the broken quick start links
- update the pip install command to be the same with GitHub readme. 
- fix some markdown format

Future enhancement: there should be some Jekyll tool to detect broken links throughout the repo. We should implement such test as the doc volume grows. 
https://www.supertechcrew.com/jekyll-check-for-broken-links/ (not verified)