### PR TITLE
Fix missing _synapse_dev_url and _spark_pool_name properties in the Spark client.

### DIFF
--- a/feathr_project/feathr/spark_provider/_synapse_submission.py
+++ b/feathr_project/feathr/spark_provider/_synapse_submission.py
@@ -218,6 +218,8 @@ class _SynapseJobRunner(object):
     Class to interact with Synapse Spark cluster
     """
     def __init__(self, synapse_dev_url, spark_pool_name, credential=None, executor_size='Small', executors=2):
+        self._synapse_dev_url = synapse_dev_url
+        self._spark_pool_name = spark_pool_name
         if credential is None:
             logger.warning('No valid Azure credential detected. Using DefaultAzureCredential')
             credential = DefaultAzureCredential()
@@ -323,7 +325,7 @@ class _SynapseJobRunner(object):
     def get_driver_log(self, job_id) -> str:
         # @see: https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/connect-monitor-azure-synapse-spark-application-level-metrics
         app_id = self.get_spark_batch_job(job_id).app_id
-        url = "%s/sparkhistory/api/v1/sparkpools/%s/livyid/%s/applications/%s/driverlog/stdout/?isDownload=true" % (self._synapse_dev_url, self._pool_name, job_id, app_id)
+        url = "%s/sparkhistory/api/v1/sparkpools/%s/livyid/%s/applications/%s/driverlog/stdout/?isDownload=true" % (self._synapse_dev_url, self._spark_pool_name, job_id, app_id)
         token = self._credential.get_token("https://dev.azuresynapse.net/.default")
         req = urllib.request.Request(url=url, headers={"authorization": "Bearer %s" % token})
         resp = urllib.request.urlopen(req)


### PR DESCRIPTION
Fix #386 , missing `_synapse_dev_url` and `_spark_pool_name` properties in the Spark client.