### PR TITLE
broken link fix and typo fix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ user_item_similarity = DerivedFeature(name="user_item_similarity",
 
 ### Define Streaming Features
 
-Read the [Streaming Source Ingestion Guide](https://linkedin.github.io/feathr/how-to-guides/streaming_source_ingestion.html) for more details.
+Read the [Streaming Source Ingestion Guide](https://linkedin.github.io/feathr/how-to-guides/streaming-source-ingestion.html) for more details.
 
 ### Point in Time Joins
 

--- a/docs/dev_guide/cloud_integration_testing.md
+++ b/docs/dev_guide/cloud_integration_testing.md
@@ -5,7 +5,7 @@ parent: Developer Guides
 ---
 # Cloud Integration Test/CI Pipeline
 
-We use [GitHub Actions](../.github/workflows/scala.yml) to do cloud integration test. Currently the integration test has 4 jobs:
+We use [GitHub Actions](https://github.com/linkedin/feathr/tree/main/.github/workflows) to do cloud integration test. Currently the integration test has 4 jobs:
 
 - running `sbt test` to verify if the scala/spark related code has passed all the test
 - running `flake8` to lint python scripts and make sure there are no obvious syntax errors

--- a/docs/dev_guide/cloud_resource_provision.md
+++ b/docs/dev_guide/cloud_resource_provision.md
@@ -7,13 +7,13 @@ parent: Developer Guides
 
 To simplify the cloud environment setup, we give end users an Azure template (with a button to have a simplified experience) so they can provision resources easily. From a high level point of view, it's a JSON file that Azure knows how to parse, and you specify the corresponding resources in the JSON file and Azure will validate and provision it for you.
 
-The JSON file is located [here](../how-to-guides/deploy.json), and developers can paste it to the [Azure Template Manager](https://ms.portal.azure.com/#blade/HubsExtension/TemplateEditorBladeV2/template/) to run the template with updates they want to have.
+The JSON file is located [here](../how-to-guides/deployment/deploy.json), and developers can paste it to the [Azure Template Manager](https://ms.portal.azure.com/#blade/HubsExtension/TemplateEditorBladeV2/template/) to run the template with updates they want to have.
 
 The template contains a lot Azure specific terms, and more details can be found here for [Azure Templates](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview). 
 
 The JSON (ARM Template - Azure Resource Manager Template) file has been built from [Bicep language](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep) which is a domain-specific language (DSL) that uses declarative syntax to deploy Azure resources.
 
-The Bicep files are here and has been translated with [deploy.json](../how-to-guides/deploy.json) file
+The Bicep files are here and has been translated with [deploy.json](../how-to-guides/deployment/deploy.json) file
 
 Here is the simplest steps for deploying Feathr resources in your Azure Subscription and configure resources.  
 
@@ -21,7 +21,7 @@ Here is the simplest steps for deploying Feathr resources in your Azure Subscrip
 
 Open Azure Cloud Shell with Powershell environment.
 
-![powreshellenv](../images/azcloud-powershell.png)
+![powershellenv](../images/azcloud-powershell.png)
 
 ## Step 2. Invoke Deployment Script  
 
@@ -32,13 +32,13 @@ Available regions can be checked with this command
     Get-AzLocation | select displayname,location
 ```
 
-```powreshell  
+```powershell
 
     iwr https://raw.githubusercontent.com/linkedin/feathr/main/docs/how-to-guides/deployFeathr.ps1 -outfile ./deployFeathr.ps1; ./deployFeathr.ps1 -AzureRegion '{Assign Your Region}'  
 
 ``` 
 
-With this command, [deployFeathr.ps1](../how-to-guides/deployFeathr.ps1) retrieves your Azure User Object Id then create Azure deployment with ARM template which have been built by [bicep files](../how-to-guides/deployment/).
+With this command, [deployFeathr.ps1](../how-to-guides/deployment/deployFeathr.ps1) retrieves your Azure User Object Id then create Azure deployment with ARM template which have been built by [bicep files](../how-to-guides/deployment/).
 
 Deployment may take up to 10 mins.  
 After deploying Azure resources for Feathr, need to install additional Python libraries for Synapse notebook environment.

--- a/docs/dev_guide/update_python_docs.md
+++ b/docs/dev_guide/update_python_docs.md
@@ -112,10 +112,10 @@ So that only this module is accessbile for end users.
 
 ### Test
 * After you have imported your own branch, you can click `Build version` to test the build result of your latest code on the branch.
-* You can click on each pannels to see the command message and warnings.
+* You can click on each panel to see the command message and warnings.
 * After the build is successful, it will show
-  the docs page(like https://xxx.readthedocs.io/en/latest/feathr.html). But they have a site cache issue. You have to refresh the site then you can see your new result.
-* Sometimes the python docs are not correctly formatted and you will see the build is successful, but you won't see any docs (just blank pages). You will see error messages like below, **though the build is successful**. Pleae make sure you fix those errors.
+  the docs page(like `https://xxx.readthedocs.io/en/latest/feathr.html`). But they have a site cache issue. You have to refresh the site then you can see your new result.
+* Sometimes the python docs are not correctly formatted and you will see the build is successful, but you won't see any docs (just blank pages). You will see error messages like below, **though the build is successful**. Please make sure you fix those errors.
 
 ```
 /home/docs/checkouts/readthedocs.org/user_builds/feathr-xiaoyzhu/checkouts/latest/feathr_project/feathr/client.py:docstring of feathr.client.FeathrClient.register_features:5: ERROR: Unexpected indentation.

--- a/docs/quickstart_synapse.md
+++ b/docs/quickstart_synapse.md
@@ -196,5 +196,5 @@ client.multi_get_online_features("nycTaxiDemoFeature", ["239", "265"], ['f_locat
 
 - Run the [demo notebook](https://github.com/linkedin/feathr/blob/main/feathr_project/feathrcli/data/feathr_user_workspace/product_recommendation_demo.ipynb) to understand the workflow of Feathr.
 - Read the [Feathr Documentation Page](https://linkedin.github.io/feathr/) page to understand the Feathr abstractions.
-- Read guide to understand [how to setup Feathr on Azure](../how-to-guides/azure-deployment.md).
+- Read guide to understand [how to setup Feathr on Azure](https://linkedin.github.io/feathr/how-to-guides/azure-deployment.html).
 - Read [Python API Documentation](https://feathr.readthedocs.io/en/latest/)


### PR DESCRIPTION
Thanks for @ahlag 's contribution in https://github.com/linkedin/feathr/pull/414, we dig out more broken links.
This PR fixed all links according to: https://github.com/ahlag/feathr/runs/7115496370?check_suite_focus=true, except:
1. https://pypi.org/manage/project/feathr/
2. https://xxx.readthedocs.io/en/latest/feathr.html 
3. https://localhost:3000

Those 3 could be bypassed / ignored. 