### PR TITLE
Update Feathr config yaml sample to callout If feathr_runtime_location not specified, the latest jar from Maven would be used

### DIFF
--- a/feathr_project/feathrcli/data/feathr_user_workspace/feathr_config.yaml
+++ b/feathr_project/feathrcli/data/feathr_user_workspace/feathr_config.yaml
@@ -94,7 +94,8 @@ spark_config:
     config_template: '{"run_name":"FEATHR_FILL_IN","new_cluster":{"spark_version":"9.1.x-scala2.12","node_type_id":"Standard_D3_v2","num_workers":2,"spark_conf":{"FEATHR_FILL_IN":"FEATHR_FILL_IN"}},"libraries":[{"jar":"FEATHR_FILL_IN"}],"spark_jar_task":{"main_class_name":"FEATHR_FILL_IN","parameters":["FEATHR_FILL_IN"]}}'
     # workspace dir for storing all the required configuration files and the jar resources. All the feature definitions will be uploaded here
     work_dir: "dbfs:/feathr_getting_started"
-    # Feathr Job configuration. Support local paths, path start with http(s)://, and paths start with dbfs:/
+    # Location of Feathr runtime jar required for Spark job submission. Support local paths, path start with http(s)://, and paths start with dbfs:/
+    # If not specified, the latest jar from Maven would be used
     # this is the default location so end users don't have to compile the runtime again.
     feathr_runtime_location: "https://azurefeathrstorage.blob.core.windows.net/public/feathr-assembly-LATEST.jar"
 


### PR DESCRIPTION
This PR fixes that the default behavior of feathr_runtime_location is not documented in config yaml file