### PR TITLE
Unified docker image to support launch registry on the flying based on environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,15 @@ FROM python:3.9
 ## Install dependencies
 RUN apt-get update -y && apt-get install -y nginx
 
-WORKDIR /usr/src/backend
-COPY ./registry/sql-registry /usr/src/backend
+
+WORKDIR /usr/src/backend#
+
+# Copy Purview registry source code and build
+RUN if [ -z "$PURVIEW_NAME" ]; then COPY ./registry/purview-registry /usr/src/backend; fi
+
+# Copy SQL registry source code and build
+RUN if [ -z "$CONNECTION_STR" ]; then COPY ./registry/sql-registry /usr/src/backend; fi
+
 RUN pip install -r requirements.txt
 
 ## Remove default nginx index page and copy ui static bundle files

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,10 @@ FROM python:3.9
 
 ## Install dependencies
 RUN apt-get update -y && apt-get install -y nginx
-
-
-WORKDIR /usr/src/backend#
-
-# Copy Purview registry source code and build
-RUN if [ -z "$PURVIEW_NAME" ]; then COPY ./registry/purview-registry /usr/src/backend; fi
-
-# Copy SQL registry source code and build
-RUN if [ -z "$CONNECTION_STR" ]; then COPY ./registry/sql-registry /usr/src/backend; fi
-
+COPY ./registry /usr/src/registry
+WORKDIR /usr/src/registry/sql-registry
+RUN pip install -r requirements.txt
+WORKDIR /usr/src/registry/purview-registry
 RUN pip install -r requirements.txt
 
 ## Remove default nginx index page and copy ui static bundle files
@@ -29,6 +23,7 @@ RUN rm -rf /usr/share/nginx/html/*
 COPY --from=ui-build /usr/src/ui/build /usr/share/nginx/html
 COPY ../deploy/nginx.conf /etc/nginx/nginx.conf
 
-# Start
-COPY ../deploy/env.sh .
-CMD ["/bin/sh", "-c", "./env.sh && nginx && uvicorn main:app --host 0.0.0.0 --port 8000"]
+## Start service and then start nginx
+WORKDIR /usr/src/registry
+COPY ./deploy/start.sh .
+CMD ["/bin/sh", "-c", "./start.sh"]

--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
+# Generate static env.config.js for UI app
 envfile=/usr/share/nginx/html/env-config.js
-
 echo "window.environment = {" > $envfile
 
 if [[ -z "${REACT_APP_AZURE_CLIENT_ID}" ]]; then
@@ -20,3 +20,19 @@ echo "}" >> $envfile
 
 echo "Successfully generated ${envfile} with following content"
 cat $envfile
+
+# Start nginx
+nginx
+
+# Start API app
+API_PORT="8000"
+
+if [ "x$PURVIEW_NAME" == "x" ]; then
+    echo "PurView flag is not configured, run SQL registry"
+    cd sql-registry
+    uvicorn main:app --host 0.0.0.0 --port $API_PORT 
+else
+    echo "PurView flag is configured, run PurView registry"
+    cd purview-registry
+    uvicorn main:app --host 0.0.0.0 --port $API_PORT 
+fi


### PR DESCRIPTION
This PR updates existing docker image to support launch UI/API apps with corresponding registry provider on the flying. When container starts, the instance will check environment variables to determine registry provider type. If purview account is detected, purview registry will launch, otherwise sql reigstry will launch.

Image has been published to feathrfeaturestore/feathr-registry

#### Example to run UI/API apps with sql registry:
```docker run --env CONNECTION_STR=<CONNECTION_STR> --env API_BASE=api/v1 -it --rm -p 3000:80 feathrfeaturestore/feathr-registry```

#### Example to run UI/API apps with purview registry:
```docker run --env API_BASE=api/v1 --env PURVIEW_NAME=<PURVIEW_NAME> --env AZURE_CLIENT_ID=<AZURE_CLIENT_ID> --env AZURE_TENANT_ID=<AZURE_TENANT_ID> --env AZURE_CLIENT_SECRET=<AZURE_CLIENT_SECRET> -it --rm -p 3000:80 feathrfeaturestore/purview-registry```

Existing images with tags feathrfeaturestore/feathr-sql-registry and feathrfeaturestore/feathr-purview-registry will be cleaned up soon.