### PR TITLE
Fix Feathr package build failure due to README.md file movement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -164,7 +164,7 @@ For a complete roadmap with estimated dates, please [visit this page](https://gi
 
 ## 👨‍👨‍👦‍👦 Community Guidelines
 
-Build for the community and build by the community. Check out [Community Guidelines](CONTRIBUTING.md).
+Build for the community and build by the community. Check out [Community Guidelines](../CONTRIBUTING.md).
 
 ## 📢 Slack Channel
 

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
 from pathlib import Path
 
-# Use the README.md in root project
+# Use the README.md from /docs
 root_path = Path(__file__).resolve().parent.parent
-long_description = (root_path / "README.md").read_text()
+long_description = (root_path / "docs/README.md").read_text()
 
 setup(
     name='feathr',


### PR DESCRIPTION
This PR fix Feathr package build failure due to README.md file movement in #447. Feathr description info has been changed to be pulled from README.md file under docs directory.