### PR TITLE
support aad application tokens

### DIFF
--- a/registry/access_control/README.md
+++ b/registry/access_control/README.md
@@ -40,13 +40,15 @@ Admin roles can add or delete roles in management UI page or through management 
 
 ### Environment Settings
 
+`ENABLE_RBAC` needs to be set to deploy a registry backend with access control plugin.
+
 | Variable| Description|
 |---|---|
 | RBAC_CONNECTION_STR| Connection String of the SQL database that host access control tables, required.|
-| RBAC_API_BASE| Aligned API base, needs to start with `/`|
+| RBAC_API_BASE| Aligned API base|
 | RBAC_REGISTRY_URL| The downstream Registry API Endpoint|
-| RBAC_AAD_INSTANCE | Set to "https://login.microsoftonline.com" by default |
-| RBAC_AAD_TENANT_ID| Used get auth url together with `RBAC_AAD_INSTANCE`, set to `common` by default|
+| RBAC_AAD_INSTANCE | Instance like "https://login.microsoftonline.com" |
+| RBAC_AAD_TENANT_ID| Used get auth url together with `RBAC_AAD_INSTANCE`|
 | RBAC_API_AUDIENCE| Used as audience to decode jwt tokens|
 
 ## Notes
@@ -58,7 +60,7 @@ Supported scenarios status are tracked below:
   - [x] API Spec Contents for Access Control Management APIs
   - [x] API Spec Contents for Registry API Access Control
   - [x] Separate Registry API and Access Control into different implementation
-  - [ ] A docker file to contain all required component for deployments
+  - [x] A docker file to contain all required component for deployments
 - SQL Implementation:
   - [x] `userroles` table CRUD through FastAPI
   - [x] `userroles` table schema & test data, could be used to make `.bacpac` file for SQL table initialize.
@@ -68,6 +70,8 @@ Supported scenarios status are tracked below:
   - [x] Hidden page `../management` for global admin to make CUD requests to `userroles` table
   - [x] Use id token in Management API Request headers to identify requestor
 - Future Enhancements:
+  - [x] Support AAD Application token  
+  - [x] Support OAuth tokens with `email` attributes
   - [ ] Functional in Feathr Client
   - [ ] Support AAD Groups
   - [ ] Support Other OAuth Providers

--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -91,10 +91,10 @@ def get_userroles(requestor: User = Depends(global_admin_access)) -> list:
 
 @router.post("/users/{user}/userroles/add", name="Add a new user role [Global Admin Required]")
 def add_userrole(project: str, user: str, role: str, reason: str, requestor: User = Depends(global_admin_access)):
-    return rbac.add_userrole(project, user, role, reason, requestor.preferred_username)
+    return rbac.add_userrole(project, user, role, reason, requestor.username)
 
 
 @router.delete("/users/{user}/userroles/delete", name="Delete a user role [Global Admin Required]")
 def delete_userrole(project: str, user: str, role: str, reason: str, requestor: User = Depends(global_admin_access)):
-    return rbac.delete_userrole(project, user, role, reason, requestor.preferred_username)
+    return rbac.delete_userrole(project, user, role, reason, requestor.username)
 

--- a/registry/access_control/rbac/access.py
+++ b/registry/access_control/rbac/access.py
@@ -35,15 +35,15 @@ def project_manage_access(project: str, user: User = Depends(authorize)) -> User
 
 
 def _project_access(project: str, user: User, access: str):
-    if rbac.validate_project_access_users(project, user.preferred_username, access):
+    if rbac.validate_project_access_users(project, user.username, access):
         return user
     else:
         raise ForbiddenAccess(
-            f"{access} privileges for project {project} required for user {user.preferred_username}")
+            f"{access} privileges for project {project} required for user {user.username}")
 
 
 def global_admin_access(user: User = Depends(authorize)):
-    if user.preferred_username in rbac.get_global_admin_users():
+    if user.username in rbac.get_global_admin_users():
         return user
     else:
         raise ForbiddenAccess('Admin privileges required')
@@ -59,5 +59,5 @@ def _get_project_from_feature(feature: str):
 
 def get_api_header(requestor: User):
     return {
-        "x-registry-requestor": requestor.preferred_username
+        "x-registry-requestor": requestor.username
     }

--- a/registry/access_control/rbac/auth.py
+++ b/registry/access_control/rbac/auth.py
@@ -9,7 +9,7 @@ import jwt
 from jwt.exceptions import ExpiredSignatureError, PyJWKError
 
 from rbac import config
-from rbac.models import User
+from rbac.models import User, UserType
 
 
 log = logging.getLogger()
@@ -33,9 +33,7 @@ class AzureADAuth(OAuth2AuthorizationCodeBearer):
             tokenUrl=f"{self.base_auth_url}/oauth2/v2.0/token",
             refreshUrl=f"{self.base_auth_url}/oauth2/v2.0/token",
             scheme_name="oauth2",
-            scopes={
-                f'api://{config.RBAC_API_CLIENT_ID}/access_as_user': 'Access API as user',
-            }
+            scopes={"https://graph.microsoft.com/User.Read": "User.Read"},
         )
 
     async def __call__(self, request: Request) -> User:
@@ -50,14 +48,37 @@ class AzureADAuth(OAuth2AuthorizationCodeBearer):
     @staticmethod
     def _get_user_from_token(decoded_token: Mapping) -> User:
         try:
-            user_id = decoded_token['oid']
+            user_id = decoded_token['sub']
         except Exception as e:
-            raise InvalidAuthorization(detail=f'Unable to extract user details from token, {e}')
+            raise InvalidAuthorization(detail=f'Unable to extract subject as unique id from token, {e}')
+
+        print(decoded_token)
+
+        aad_user_key = "preferred_username"
+        aad_app_key = "appid"
+        common_user_key = "email"
+        name = decoded_token.get("name", "")
+
+        if aad_user_key in decoded_token:
+            username = decoded_token.get(aad_user_key)
+            type = UserType.AAD_USER
+        elif aad_app_key in decoded_token.keys:
+            username = decoded_token.get(aad_app_key)
+            name = decoded_token.get("app_displayname", "")
+            type = UserType.AAD_APP
+        elif common_user_key in decoded_token.keys:
+            username = decoded_token.get(common_user_key)
+            type = UserType.COMMON_USER
+        else:
+            log.debug(f"unknown user type {decoded_token}")
+            username = user_id
+            type = UserType.UNKNOWN
 
         return User(
             id=user_id,
-            name=decoded_token.get('name', ''),
-            preferred_username=decoded_token.get('preferred_username', ''),
+            name=name,
+            username=username,
+            type = type,
             roles=decoded_token.get('roles', [])
         )
 
@@ -107,7 +128,7 @@ class AzureADAuth(OAuth2AuthorizationCodeBearer):
     def _decode_token(self, token: str) -> Mapping:
         key_id = self._get_key_id(token)
         if not key_id:
-            raise InvalidAuthorization('The token does not contain kid')
+            raise InvalidAuthorization(f'The token does not contain kid: {token}')
         key = self._get_token_key(key_id)
         try:
             decode = jwt.decode(token, key=key, algorithms=[

--- a/registry/access_control/rbac/auth.py
+++ b/registry/access_control/rbac/auth.py
@@ -52,8 +52,6 @@ class AzureADAuth(OAuth2AuthorizationCodeBearer):
         except Exception as e:
             raise InvalidAuthorization(detail=f'Unable to extract subject as unique id from token, {e}')
 
-        print(decoded_token)
-
         aad_user_key = "preferred_username"
         aad_app_key = "appid"
         common_user_key = "email"

--- a/registry/access_control/rbac/models.py
+++ b/registry/access_control/rbac/models.py
@@ -6,9 +6,15 @@ from enum import Enum
 class User(BaseModel):
     id: str
     name: str
-    preferred_username: str
+    username: str
+    type: str
     roles: List[str]
 
+class UserType(str, Enum):
+    AAD_USER = "aad_user",
+    AAD_APP = "aad_application",
+    COMMON_USER = "common_user",
+    UNKNOWN = "unknown",
 
 SUPER_ADMIN_SCOPE = "global"
 


### PR DESCRIPTION
This PR extend the token decode functions to 
- Support `AAD Application` by using `appid` as username
- Support other Oauth tokens by
    - changing required id from `oid` to `sub`
    - adding 2 user types with `email` / `sub` as username 
- Update readme

