### PR TITLE
Update Dockerfile to point to current nginx.conf file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ RUN pip install -r requirements.txt
 ## Remove default nginx index page and copy ui static bundle files
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=ui-build /usr/src/ui/build /usr/share/nginx/html
-COPY ../deploy/nginx.conf /etc/nginx/nginx.conf
+COPY ./deploy/nginx.conf /etc/nginx/nginx.conf
 
 ## Start service and then start nginx
 WORKDIR /usr/src/registry
 COPY ./deploy/start.sh .
+RUN ["chmod", "+x", "./start.sh"]
 CMD ["/bin/sh", "-c", "./start.sh"]


### PR DESCRIPTION
I discovered that the Docker build fails from following the Azure quickstart guide. The error stems from incorrect nginx.conf path:
![image](https://user-images.githubusercontent.com/23062420/179625632-b4d785d9-81a2-4641-91a1-4996a2b317e5.png)

I verified that the docker build works correctly after the fix.