### PR TITLE
Get project name from backend rather than param for access control plugin APIs

### DIFF
--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -34,26 +34,23 @@ def get_project_features(project: str, keyword: Optional[str] = None, requestor:
     response = requests.get(registry_url + "/projects/" + project + "/features", headers = get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
-
-@router.get("/features/{feature}", name="Get a single feature by feature Id [Read Access Required]")
-def get_feature(feature: str, project: str, requestor: User = Depends(project_read_access)) -> dict:
-    response = requests.get(registry_url + "/features/" + feature, headers = get_api_header(requestor)).content.decode('utf-8')
-    return json.loads(response)
-
-# To make sure the consistent experience of Registry API and Access Control Plugin.
-# Even if user doesn't provide the project name, the API can still work.
 @router.get("/features/{feature}", name="Get a single feature by feature Id [Read Access Required]")
 def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
     response = requests.get(registry_url + "/features/" + feature, headers = get_api_header(requestor)).content.decode('utf-8')
     ret = json.loads(response)
-    validate_project_access_for_feature(ret["qualified_name"], requestor, AccessType.READ)
+
+    feature_qualifiedName = ret['attributes']['qualifiedName']
+    validate_project_access_for_feature(feature_qualifiedName, requestor, AccessType.READ)
     return ret
 
-@router.get("/features/{feature}/lineage/{project}", name="Get Feature Lineage [Read Access Required]")
-def get_feature_lineage(feature: str, requestor: User = Depends(project_read_access)) -> dict:
+@router.get("/features/{feature}/lineage", name="Get Feature Lineage [Read Access Required]")
+def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> dict:
     response = requests.get(registry_url + "/features/" + feature + "/lineage", headers = get_api_header(requestor)).content.decode('utf-8')
-    return json.loads(response)
+    ret = json.loads(response)
 
+    feature_qualifiedName = ret['guidEntityMap'][feature]['attributes']['qualifiedName']
+    validate_project_access_for_feature(feature_qualifiedName, requestor, AccessType.READ)
+    return ret
 
 @router.post("/projects", name="Create new project with definition [Auth Required]")
 def new_project(definition: dict, requestor: User = Depends(get_user)) -> dict:

--- a/registry/access_control/rbac/access.py
+++ b/registry/access_control/rbac/access.py
@@ -54,7 +54,7 @@ def validate_project_access_for_feature(feature:str, user:str, access:str):
 
 
 def _get_project_from_feature(feature: str):
-    feature_delimiter = "__request_features__"
+    feature_delimiter = "__"
     return feature.split(feature_delimiter)[0]
 
 def get_api_header(requestor: User):


### PR DESCRIPTION
Access control plugin used to rely on a project name parameter to validate project level RBAC.
The logic is now updated to extract project name from backend registry for more consistency user experience. 