### PR TITLE
UDF plugin API

### DIFF
--- a/src/main/scala/com/linkedin/feathr/offline/PostTransformationUtil.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/PostTransformationUtil.scala
@@ -129,7 +129,7 @@ private[offline] object PostTransformationUtil {
       featureType: FeatureTypes): Try[FeatureValue] = Try {
     val args = Map(featureName -> Some(featureValue))
     val variableResolverFactory = new FeatureVariableResolverFactory(args)
-    val transformedValue = MVEL.executeExpression(compiledExpression, featureValue, variableResolverFactory)
+    val transformedValue = MvelContext.executeExpressionWithPluginSupport(compiledExpression, featureValue, variableResolverFactory)
     CoercionUtilsScala.coerceToFeatureValue(transformedValue, featureType)
   }
 

--- a/src/main/scala/com/linkedin/feathr/offline/anchored/anchorExtractor/SimpleConfigurableAnchorExtractor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/anchored/anchorExtractor/SimpleConfigurableAnchorExtractor.scala
@@ -73,7 +73,7 @@ private[offline] class SimpleConfigurableAnchorExtractor( @JsonProperty("key") k
     // be more strict for resolving keys (don't swallow exceptions)
     keyExpression.map(k =>
       try {
-        Option(MVEL.executeExpression(k, datum)) match {
+        Option(MvelContext.executeExpressionWithPluginSupport(k, datum)) match {
           case None => null
           case Some(keys) => keys.toString
         }

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/DfWiseAnchorExtractorUdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/DfWiseAnchorExtractorUdfAdaptor.scala
@@ -1,0 +1,7 @@
+package com.linkedin.feathr.offline.client.plugins
+
+import com.linkedin.feathr.sparkcommon.SimpleAnchorExtractorSpark
+
+trait DfWiseAnchorExtractorUdfAdaptor extends UdfAdaptor {
+  def adaptUdf(udf: AnyRef): SimpleAnchorExtractorSpark
+}

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/DfWiseAnchorExtractorUdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/DfWiseAnchorExtractorUdfAdaptor.scala
@@ -1,7 +1,0 @@
-package com.linkedin.feathr.offline.client.plugins
-
-import com.linkedin.feathr.sparkcommon.SimpleAnchorExtractorSpark
-
-trait DfWiseAnchorExtractorUdfAdaptor extends UdfAdaptor {
-  def adaptUdf(udf: AnyRef): SimpleAnchorExtractorSpark
-}

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/FeathrUdfPluginContext.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/FeathrUdfPluginContext.scala
@@ -1,0 +1,62 @@
+package com.linkedin.feathr.offline.client.plugins
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.collection.JavaConverters._
+
+object FeathrUdfPluginContext {
+  val registeredUdfAdaptors = new ConcurrentHashMap[Class[_], UdfAdaptor]().asScala
+  val adaptorSubclassCache = new ConcurrentHashMap[Class[_], Option[UdfAdaptor]]().asScala
+
+  def registerUdf(className: Class[_], adaptor: UdfAdaptor): Unit = {
+    this.synchronized {
+      if (registeredUdfAdaptors.contains(className)) {
+        throw new IllegalArgumentException(s"Class ${className} already registered.")
+      }
+      registeredUdfAdaptors.keys.foreach(alreadyRegistered => {
+        if (alreadyRegistered.isAssignableFrom(className) || className.isAssignableFrom(alreadyRegistered)) {
+          throw new IllegalArgumentException(s"Class to be registered ${className} is a subtype or supertype of already" +
+            s" registered class ${alreadyRegistered}")
+        }
+      })
+      registeredUdfAdaptors.put(className, adaptor)
+      adaptorSubclassCache.clear()
+    }
+  }
+
+  def isRegisteredRowWiseAnchorExtractorType(className: Class[_]): Boolean = {
+    getCachedAdaptor(className) match {
+      case Some(_: RowWiseAnchorExtractorUdfAdaptor) => true
+      case _ => false
+    }
+  }
+
+  def getRowWiseAnchorExtractorAdaptor(className: Class[_]): RowWiseAnchorExtractorUdfAdaptor = {
+    getCachedAdaptor(className) match {
+      case Some(adaptor: RowWiseAnchorExtractorUdfAdaptor) => adaptor
+      case _ => throw new RuntimeException(s"No UDF adaptor defined for class ${className}")
+    }
+  }
+
+  def isRegisteredDfWiseAnchorExtractorType(className: Class[_]): Boolean = {
+    getCachedAdaptor(className) match {
+      case Some(_: RowWiseAnchorExtractorUdfAdaptor) => true
+      case _ => false
+    }
+  }
+
+  def getDfWiseAnchorExtractorAdaptor(className: Class[_]): DfWiseAnchorExtractorUdfAdaptor = {
+    getCachedAdaptor(className) match {
+      case Some(adaptor: DfWiseAnchorExtractorUdfAdaptor) => adaptor
+      case _ => throw new RuntimeException(s"No UDF adaptor defined for class ${className}")
+    }
+  }
+
+  private def findRegisteredParent(className: Class[_]): Option[Class[_]] = {
+    registeredUdfAdaptors.keys.find(registeredClass => registeredClass.isAssignableFrom(className))
+  }
+
+  private def getCachedAdaptor(className: Class[_]): Option[UdfAdaptor] = {
+    adaptorSubclassCache.getOrElseUpdate(className, findRegisteredParent(className).flatMap(registeredUdfAdaptors.get))
+  }
+
+}

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/FeathrUdfPluginContext.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/FeathrUdfPluginContext.scala
@@ -1,62 +1,23 @@
 package com.linkedin.feathr.offline.client.plugins
 
-import java.util.concurrent.ConcurrentHashMap
-import scala.collection.JavaConverters._
+import scala.collection.mutable
 
+/**
+ * A shared registry for loading [[UdfAdaptor]]s, which basically can tell Feathr's runtime how to support different
+ * kinds of "external" UDFs not natively known to Feathr, but which have similar behavior to Feathr's.
+ *
+ * All "external" UDF classes are required to have a public default zero-arg constructor.
+ */
 object FeathrUdfPluginContext {
-  val registeredUdfAdaptors = new ConcurrentHashMap[Class[_], UdfAdaptor]().asScala
-  val adaptorSubclassCache = new ConcurrentHashMap[Class[_], Option[UdfAdaptor]]().asScala
+  val registeredUdfAdaptors = mutable.Buffer[UdfAdaptor[_]]()
 
-  def registerUdf(className: Class[_], adaptor: UdfAdaptor): Unit = {
+  def registerUdfAdaptor(adaptor: UdfAdaptor[_]): Unit = {
     this.synchronized {
-      if (registeredUdfAdaptors.contains(className)) {
-        throw new IllegalArgumentException(s"Class ${className} already registered.")
-      }
-      registeredUdfAdaptors.keys.foreach(alreadyRegistered => {
-        if (alreadyRegistered.isAssignableFrom(className) || className.isAssignableFrom(alreadyRegistered)) {
-          throw new IllegalArgumentException(s"Class to be registered ${className} is a subtype or supertype of already" +
-            s" registered class ${alreadyRegistered}")
-        }
-      })
-      registeredUdfAdaptors.put(className, adaptor)
-      adaptorSubclassCache.clear()
+      registeredUdfAdaptors += adaptor
     }
   }
 
-  def isRegisteredRowWiseAnchorExtractorType(className: Class[_]): Boolean = {
-    getCachedAdaptor(className) match {
-      case Some(_: RowWiseAnchorExtractorUdfAdaptor) => true
-      case _ => false
-    }
+  def getRegisteredUdfAdaptor(clazz: Class[_]): Option[UdfAdaptor[_]] = {
+    registeredUdfAdaptors.find(_.canAdapt(clazz))
   }
-
-  def getRowWiseAnchorExtractorAdaptor(className: Class[_]): RowWiseAnchorExtractorUdfAdaptor = {
-    getCachedAdaptor(className) match {
-      case Some(adaptor: RowWiseAnchorExtractorUdfAdaptor) => adaptor
-      case _ => throw new RuntimeException(s"No UDF adaptor defined for class ${className}")
-    }
-  }
-
-  def isRegisteredDfWiseAnchorExtractorType(className: Class[_]): Boolean = {
-    getCachedAdaptor(className) match {
-      case Some(_: RowWiseAnchorExtractorUdfAdaptor) => true
-      case _ => false
-    }
-  }
-
-  def getDfWiseAnchorExtractorAdaptor(className: Class[_]): DfWiseAnchorExtractorUdfAdaptor = {
-    getCachedAdaptor(className) match {
-      case Some(adaptor: DfWiseAnchorExtractorUdfAdaptor) => adaptor
-      case _ => throw new RuntimeException(s"No UDF adaptor defined for class ${className}")
-    }
-  }
-
-  private def findRegisteredParent(className: Class[_]): Option[Class[_]] = {
-    registeredUdfAdaptors.keys.find(registeredClass => registeredClass.isAssignableFrom(className))
-  }
-
-  private def getCachedAdaptor(className: Class[_]): Option[UdfAdaptor] = {
-    adaptorSubclassCache.getOrElseUpdate(className, findRegisteredParent(className).flatMap(registeredUdfAdaptors.get))
-  }
-
 }

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/RowWiseAnchorExtractorUdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/RowWiseAnchorExtractorUdfAdaptor.scala
@@ -1,0 +1,7 @@
+package com.linkedin.feathr.offline.client.plugins
+
+import com.linkedin.feathr.common.AnchorExtractor
+
+trait RowWiseAnchorExtractorUdfAdaptor extends UdfAdaptor {
+  def adaptUdf(udf: AnyRef): AnchorExtractor[_]
+}

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/RowWiseAnchorExtractorUdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/RowWiseAnchorExtractorUdfAdaptor.scala
@@ -1,7 +1,0 @@
-package com.linkedin.feathr.offline.client.plugins
-
-import com.linkedin.feathr.common.AnchorExtractor
-
-trait RowWiseAnchorExtractorUdfAdaptor extends UdfAdaptor {
-  def adaptUdf(udf: AnyRef): AnchorExtractor[_]
-}

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/UdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/UdfAdaptor.scala
@@ -1,0 +1,5 @@
+package com.linkedin.feathr.offline.client.plugins
+
+trait UdfAdaptor {
+
+}

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/UdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/UdfAdaptor.scala
@@ -48,6 +48,6 @@ trait SimpleAnchorExtractorSparkAdaptor extends UdfAdaptor[SimpleAnchorExtractor
 trait FeatureDerivationFunctionAdaptor extends UdfAdaptor[FeatureDerivationFunction]
 
 /**
- * An adaptor that can "tell Feathr how to use" a UDF type that can act in place of [[FeatureDerivationFunction]]
+ * An adaptor that can "tell Feathr how to use" a UDF type that can act in place of [[SourceKeyExtractor]]
  */
 trait SourceKeyExtractorAdaptor extends UdfAdaptor[SourceKeyExtractor]

--- a/src/main/scala/com/linkedin/feathr/offline/client/plugins/UdfAdaptor.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/client/plugins/UdfAdaptor.scala
@@ -1,5 +1,53 @@
 package com.linkedin.feathr.offline.client.plugins
 
-trait UdfAdaptor {
+import com.linkedin.feathr.common.{AnchorExtractor, FeatureDerivationFunction}
+import com.linkedin.feathr.sparkcommon.{SimpleAnchorExtractorSpark, SourceKeyExtractor}
 
+/**
+ * Tells Feathr how to use UDFs that are defined in "external" non-Feathr UDF classes (i.e. that don't extend from
+ * Feathr's AnchorExtractor or other UDF traits). An adaptor must match the external UDF class to a specific kind of
+ * Feathr UDF – see child traits below for the various options.
+ *
+ * All "external" UDF classes are required to have a public default zero-arg constructor.
+ *
+ * @tparam T the internal Feathr UDF class whose behavior the external UDF can be translated to
+ */
+sealed trait UdfAdaptor[T] extends Serializable {
+  /**
+   * Indicates whether this adaptor can be applied to an object of the provided class.
+   *
+   * Implementations should usually look like <pre>classOf[UdfTraitThatIsNotPartOfFeathr].isAssignableFrom(clazz)</pre>
+   *
+   * @param clazz some external UDF type
+   * @return true if this adaptor can "adapt" the given class type; false otherwise
+   */
+  def canAdapt(clazz: Class[_]): Boolean
+
+  /**
+   * Returns an instance of a Feathr UDF, that follows the behavior of some external UDF instance, e.g. via delegation.
+   *
+   * @param externalUdf instance of the "external" UDF
+   * @return the Feathr UDF
+   */
+  def adaptUdf(externalUdf: AnyRef): T
 }
+
+/**
+ * An adaptor that can "tell Feathr how to use" a UDF type that can act in place of [[AnchorExtractor]]
+ */
+trait AnchorExtractorAdaptor extends UdfAdaptor[AnchorExtractor[_]]
+
+/**
+ * An adaptor that can "tell Feathr how to use" a UDF type that can act in place of [[SimpleAnchorExtractorSpark]]
+ */
+trait SimpleAnchorExtractorSparkAdaptor extends UdfAdaptor[SimpleAnchorExtractorSpark]
+
+/**
+ * An adaptor that can "tell Feathr how to use" a UDF type that can act in place of [[FeatureDerivationFunction]]
+ */
+trait FeatureDerivationFunctionAdaptor extends UdfAdaptor[FeatureDerivationFunction]
+
+/**
+ * An adaptor that can "tell Feathr how to use" a UDF type that can act in place of [[FeatureDerivationFunction]]
+ */
+trait SourceKeyExtractorAdaptor extends UdfAdaptor[SourceKeyExtractor]

--- a/src/main/scala/com/linkedin/feathr/offline/derived/DerivedFeature.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/derived/DerivedFeature.scala
@@ -30,6 +30,9 @@ private[offline] case class DerivedFeature(
    * get the row-based FeatureDerivationFunction, note that some of the derivations that derive from FeatureDerivationFunctionBase
    * are not subclass of FeatureDerivationFunction, e.g, [[FeatureDerivationFunctionSpark]], in such cases, this function will
    * throw exception, make sure you will not call this function for such cases.
+   *
+   * TODO: The above described condition is bad; ideally this class should capture the information about what type of
+   *       derivation function this is in a type-safe way.
    */
   def getAsFeatureDerivationFunction(): FeatureDerivationFunction = derivation.asInstanceOf[FeatureDerivationFunction]
 

--- a/src/main/scala/com/linkedin/feathr/offline/job/FeatureTransformation.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/job/FeatureTransformation.scala
@@ -6,6 +6,7 @@ import com.linkedin.feathr.offline.anchored.anchorExtractor.{SQLConfigurableAnch
 import com.linkedin.feathr.offline.anchored.feature.{FeatureAnchor, FeatureAnchorWithSource}
 import com.linkedin.feathr.offline.anchored.keyExtractor.MVELSourceKeyExtractor
 import com.linkedin.feathr.offline.client.DataFrameColName
+import com.linkedin.feathr.offline.client.plugins.FeathrUdfPluginContext
 import com.linkedin.feathr.offline.config.{MVELFeatureDefinition, TimeWindowFeatureDefinition}
 import com.linkedin.feathr.offline.generation.IncrementalAggContext
 import com.linkedin.feathr.offline.job.FeatureJoinJob.FeatureName
@@ -23,7 +24,6 @@ import com.linkedin.feathr.swj.aggregate.AggregationType
 import com.linkedin.feathr.{common, offline}
 import org.apache.log4j.Logger
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -179,8 +179,18 @@ private[offline] object FeatureTransformation {
         DataFrameBasedSqlEvaluator.transform(transformer, df, featureNamePrefixPairs, featureTypeConfigs)
       case transformer: AnchorExtractor[_] =>
         DataFrameBasedRowEvaluator.transform(transformer, df, featureNamePrefixPairs, featureTypeConfigs)
-      case _ => throw new FeathrFeatureTransformationException(ErrorLabel.FEATHR_USER_ERROR, s"cannot find valid Transformer for ${featureAnchorWithSource}")
-
+      case transformer =>
+        val transformerClass = transformer.getClass
+        if (FeathrUdfPluginContext.isRegisteredRowWiseAnchorExtractorType(transformerClass)) {
+          val adapter = FeathrUdfPluginContext.getRowWiseAnchorExtractorAdaptor(transformerClass)
+          // Question: Can this be made to work for cases like Frame's GenericAnchorExtractorSpark and SpecificRecordSourceKeyExtractor too?
+          DataFrameBasedRowEvaluator.transform(adapter.adaptUdf(transformer), df, featureNamePrefixPairs, featureTypeConfigs)
+        } else if (FeathrUdfPluginContext.isRegisteredDfWiseAnchorExtractorType(transformerClass)) {
+          val adapter = FeathrUdfPluginContext.getDfWiseAnchorExtractorAdaptor(transformerClass)
+          DataFrameBasedSqlEvaluator.transform(adapter.adaptUdf(transformer), df, featureNamePrefixPairs, featureTypeConfigs)
+        } else {
+          throw new FeathrFeatureTransformationException(ErrorLabel.FEATHR_USER_ERROR, s"cannot find valid Transformer for ${featureAnchorWithSource}")
+        }
     }
     // Check for whether there are duplicate columns in the transformed DataFrame, typically this is because
     // the feature name is the same as some field name

--- a/src/main/scala/com/linkedin/feathr/offline/mvel/MvelUtils.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/mvel/MvelUtils.scala
@@ -17,7 +17,7 @@ private[offline] object MvelUtils {
   // (We might not want to check for null explicitly everywhere)
   def executeExpression(compiledExpression: Any, input: Any, resolverFactory: VariableResolverFactory, featureName: String = ""): Option[AnyRef] = {
     try {
-      Option(MVEL.executeExpression(compiledExpression, input, resolverFactory))
+      Option(MvelContext.executeExpressionWithPluginSupport(compiledExpression, input, resolverFactory))
     } catch {
       case e: RuntimeException =>
         log.debug(s"Expression $compiledExpression on input record $input threw exception", e)

--- a/src/main/scala/com/linkedin/feathr/offline/mvel/plugins/FeathrMvelPluginContext.java
+++ b/src/main/scala/com/linkedin/feathr/offline/mvel/plugins/FeathrMvelPluginContext.java
@@ -1,6 +1,7 @@
 package com.linkedin.feathr.offline.mvel.plugins;
 
 import com.linkedin.feathr.common.FeatureValue;
+import com.linkedin.feathr.common.InternalApi;
 import org.mvel2.ConversionHandler;
 import org.mvel2.DataConversion;
 
@@ -34,7 +35,7 @@ public class FeathrMvelPluginContext {
    * @param <T> type parameter for the "other" feature value class
    */
   @SuppressWarnings("unchecked")
-  public <T> void addFeatureTypeAdaptor(Class<T> clazz, FeatureValueTypeAdaptor<T> typeAdaptor) {
+  public static <T> void addFeatureTypeAdaptor(Class<T> clazz, FeatureValueTypeAdaptor<T> typeAdaptor) {
     // TODO: MAKE SURE clazz IS NOT ONE OF THE CLASSES ALREADY COVERED IN org.mvel2.DataConversion.CONVERTERS!
     //       IF WE OVERRIDE ANY OF THOSE, IT MIGHT CAUSE MVEL TO BEHAVE IN STRANGE AND UNEXPECTED WAYS!
     TYPE_ADAPTORS.put(clazz, typeAdaptor);

--- a/src/main/scala/com/linkedin/feathr/offline/mvel/plugins/FeathrMvelPluginContext.java
+++ b/src/main/scala/com/linkedin/feathr/offline/mvel/plugins/FeathrMvelPluginContext.java
@@ -1,0 +1,78 @@
+package com.linkedin.feathr.offline.mvel.plugins;
+
+import com.linkedin.feathr.common.FeatureValue;
+import org.mvel2.ConversionHandler;
+import org.mvel2.DataConversion;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+
+/**
+ * A plugin that allows an advanced user to add additional capabilities or behaviors to Feathr's MVEL runtime.
+ *
+ * NOTE: This class is intended for advanced users only, and specifically as a "migration aid" for migrating from
+ * some previous versions of Feathr whose FeatureValue representations had a different class name, while preserving
+ * compatibility with feature definitions written against those older versions of Feathr.
+ */
+public class FeathrMvelPluginContext {
+  // TODO: Does this need to be "translated" into a different pattern whereby we track the CLASSNAME of the type adaptors
+  //       instead of the instance, such that the class mappings can be broadcasted via Spark and then reinitialized on
+  //       executor hosts?
+  private static final ConcurrentMap<Class<?>, FeatureValueTypeAdaptor<?>> TYPE_ADAPTORS;
+
+  static {
+    TYPE_ADAPTORS = new ConcurrentHashMap<>();
+    DataConversion.addConversionHandler(FeatureValue.class, new FeathrFeatureValueConversionHandler());
+  }
+
+  /**
+   * Add a type adaptor to Feathr's MVEL runtime, that will enable Feathr's expressions to support some alternative
+   * class representation of {@link FeatureValue} via coercion.
+   * @param clazz the class of the "other" alternative representation of feature value
+   * @param typeAdaptor the type adaptor that can convert between the "other" representation and {@link FeatureValue}
+   * @param <T> type parameter for the "other" feature value class
+   */
+  @SuppressWarnings("unchecked")
+  public <T> void addFeatureTypeAdaptor(Class<T> clazz, FeatureValueTypeAdaptor<T> typeAdaptor) {
+    // TODO: MAKE SURE clazz IS NOT ONE OF THE CLASSES ALREADY COVERED IN org.mvel2.DataConversion.CONVERTERS!
+    //       IF WE OVERRIDE ANY OF THOSE, IT MIGHT CAUSE MVEL TO BEHAVE IN STRANGE AND UNEXPECTED WAYS!
+    TYPE_ADAPTORS.put(clazz, typeAdaptor);
+    DataConversion.addConversionHandler(clazz, new ExternalFeatureValueConversionHandler(typeAdaptor));
+  }
+
+  static class FeathrFeatureValueConversionHandler implements ConversionHandler {
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object convertFrom(Object in) {
+      FeatureValueTypeAdaptor<Object> adaptor = (FeatureValueTypeAdaptor<Object>) TYPE_ADAPTORS.get(in.getClass());
+      if (adaptor == null) {
+        throw new IllegalArgumentException("Can't convert to Feathr FeatureValue from " + in);
+      }
+      return adaptor.toFeathrFeatureValue(in);
+    }
+
+    @Override
+    public boolean canConvertFrom(Class cls) {
+      return TYPE_ADAPTORS.containsKey(cls);
+    }
+  }
+
+  static class ExternalFeatureValueConversionHandler implements ConversionHandler {
+    private final FeatureValueTypeAdaptor<?> _adaptor;
+
+    public ExternalFeatureValueConversionHandler(FeatureValueTypeAdaptor<?> adaptor) {
+      _adaptor = adaptor;
+    }
+
+    @Override
+    public Object convertFrom(Object in) {
+      return _adaptor.fromFeathrFeatureValue((FeatureValue) in);
+    }
+
+    @Override
+    public boolean canConvertFrom(Class cls) {
+      return FeatureValue.class.equals(cls);
+    }
+  }
+}

--- a/src/main/scala/com/linkedin/feathr/offline/mvel/plugins/FeatureValueTypeAdaptor.java
+++ b/src/main/scala/com/linkedin/feathr/offline/mvel/plugins/FeatureValueTypeAdaptor.java
@@ -1,0 +1,38 @@
+package com.linkedin.feathr.offline.mvel.plugins;
+
+import com.linkedin.feathr.common.FeatureValue;
+
+/**
+ * A converter that knows how to convert back and forth between Feathr's {@link FeatureValue} and some other
+ * representation. Implementations' "to" and "from" methods are expected to be inverses of each other, such that
+ * toFeathrFeatureValue(fromFeathrFeatureValue(x)) = x and fromFeathrFeatureValue(toFeathrFeatureValue(x)) = x,
+ * for any instance 'x' of FeatureValue.
+ *
+ * NOTE: This class is intended for advanced users only, and specifically as a "migration aid" for migrating from
+ * some previous versions of Feathr whose FeatureValue representations had a different class name, while preserving
+ * compatibility with feature definitions written against those older versions of Feathr.
+ *
+ * @param <T> the other, alternative FeatureValue representation
+ */
+public interface FeatureValueTypeAdaptor<T> {
+
+  /**
+   * Convert from the "other" representation into Feathr FeatureValue.
+   *
+   * It is expected to be the inverse of {@link #fromFeathrFeatureValue(FeatureValue)}
+   *
+   * @param other the feature value in the "other" representation
+   * @return the feature value represented as a Feathr FeatureValue
+   */
+  FeatureValue toFeathrFeatureValue(T other);
+
+  /**
+   * Convert from Feathr FeatureValue into the "other" representation.
+   *
+   * It is expected to be the inverse of {@link #toFeathrFeatureValue(Object)}
+   *
+   * @param featureValue the feature value represented as a Feathr FeatureValue
+   * @return the feature value in the "other" representation
+   */
+  T fromFeathrFeatureValue(FeatureValue featureValue);
+}

--- a/src/test/java/com/linkedin/feathr/offline/TestMvelExpression.java
+++ b/src/test/java/com/linkedin/feathr/offline/TestMvelExpression.java
@@ -2,18 +2,18 @@ package com.linkedin.feathr.offline;
 
 import com.linkedin.feathr.offline.mvel.MvelContext;
 import java.io.Serializable;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.mvel2.MVEL;
+import org.mvel2.*;
 import org.mvel2.integration.PropertyHandlerFactory;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.MapVariableResolverFactory;
 import org.mvel2.optimizers.OptimizerFactory;
 import org.scalatest.testng.TestNGSuite;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -65,5 +65,136 @@ public class TestMvelExpression extends TestNGSuite {
     assertEquals(MVEL.executeExpression(compiledExpression, secondRecord, factory, String.class), "testMapValue");
     assertEquals(MVEL.executeExpression(compiledExpression2, secondRecord, factory, String.class), "testMapValue");
     assertEquals(MVEL.executeExpression(compiledExpression3, secondRecord, factory, String.class), "testMapValue");
+  }
+
+  @Test
+  public void demonstrateCompatibilityCapabilityForDifferentFeatureValueTypes() throws Exception {
+    ParserConfiguration parserConfiguration = new ParserConfiguration();
+    parserConfiguration.addImport("createFeatureValue1", getClass().getMethod("createFeatureValue1", String.class));
+    parserConfiguration.addImport("createFeatureValue2", getClass().getMethod("createFeatureValue2", String.class));
+    parserConfiguration.addImport("processFeatureValue1", getClass().getMethod("processFeatureValue1", FeatureValue1.class));
+    parserConfiguration.addImport("processFeatureValue2", getClass().getMethod("processFeatureValue2", FeatureValue2.class));
+    ParserContext parserContext = new ParserContext(parserConfiguration);
+
+    ConversionHandler featureValue2ConversionHandler = new ConversionHandler() {
+      @Override
+      public Object convertFrom(Object in) {
+        String contents = ((FeatureValue1) in).getContents1();
+        return new FeatureValue2(contents);
+      }
+
+      @Override
+      public boolean canConvertFrom(Class cls) {
+        return FeatureValue1.class.equals(cls);
+      }
+    };
+
+    ConversionHandler featureValue1ConversionHandler = new ConversionHandler() {
+      @Override
+      public Object convertFrom(Object in) {
+        String contents = ((FeatureValue2) in).getContents2();
+        return new FeatureValue1(contents);
+      }
+
+      @Override
+      public boolean canConvertFrom(Class cls) {
+        return FeatureValue2.class.equals(cls);
+      }
+    };
+
+    // Use MVEL DataConversion API to enable magical coercion between FeatureValue1 and FeatureValue2
+    DataConversion.addConversionHandler(FeatureValue1.class, featureValue1ConversionHandler);
+    DataConversion.addConversionHandler(FeatureValue2.class, featureValue2ConversionHandler);
+
+    {
+      // Basic sanity test: ensure UDF to make FeatureValue1 works
+      String expression = "createFeatureValue1('foooo')";
+      Serializable compiledExpression = MVEL.compileExpression(expression, parserContext);
+      Object output = MVEL.executeExpression(compiledExpression);
+      System.out.println(output);
+      Assert.assertEquals(((FeatureValue1) output).getContents1(), "foooo");
+    }
+    {
+      // Call a UDF that produces FeatureValue1, and feed it to a different UDF that consumes FeatureValue2
+      String expression = "processFeatureValue2(createFeatureValue1('foooo'))";
+      Serializable compiledExpression = MVEL.compileExpression(expression, parserContext);
+      Object output = MVEL.executeExpression(compiledExpression);
+      System.out.println(output);
+      Assert.assertEquals(output, "foooo");
+    }
+    {
+      // Run an MVEL expression that produces FeatureValue1, and invoke MVEL in a way that converts to FeatureValue2 without
+      // the calling code needing to know about the existence of FeatureValue1.
+      String expression = "createFeatureValue1('foooo')";
+      Serializable compiledExpression = MVEL.compileExpression(expression, parserContext);
+      Object output = maybeCoerceMvelOutput(MVEL.executeExpression(compiledExpression), FeatureValue2.class);
+      System.out.println(output);
+      Assert.assertEquals(output.getClass(), FeatureValue2.class);
+      Assert.assertEquals(((FeatureValue2) output).getContents2(), "foooo");
+    }
+    {
+      // Run an MVEL expression that produces some other output type, e.g. int. Ensure that "regular" behavior is
+      // followed, and that we don't accidentally choke by trying to convert it to FeatureValue2.
+      String expression = "123";
+      Serializable compiledExpression = MVEL.compileExpression(expression, parserContext);
+      Object output = maybeCoerceMvelOutput(MVEL.executeExpression(compiledExpression), FeatureValue2.class);
+      System.out.println(output);
+      Assert.assertEquals(output, 123);
+    }
+  }
+
+  public static Object maybeCoerceMvelOutput(Object data, Class<?> maybeTarget) {
+    if (DataConversion.canConvert(maybeTarget, data.getClass())) {
+      return DataConversion.convert(data, maybeTarget);
+    } else {
+      return data;
+    }
+  }
+
+  public static FeatureValue1 createFeatureValue1(String contents) {
+    return new FeatureValue1(contents);
+  }
+  public static FeatureValue2 createFeatureValue2(String contents) {
+    return new FeatureValue2(contents);
+  }
+  public static String processFeatureValue1(FeatureValue1 data) {
+    return data.getContents1();
+  }
+  public static String processFeatureValue2(FeatureValue2 data) {
+    return data.getContents2();
+  }
+
+  public static class FeatureValue1 {
+    private final String contents;
+
+    public FeatureValue1(String contents) {
+      this.contents = contents;
+    }
+
+    public String getContents1() {
+      return contents;
+    }
+
+    @Override
+    public String toString() {
+      return "FeatureValue1{contents='" + contents + "'}";
+    }
+  }
+
+  public static class FeatureValue2 {
+    private final String contents;
+
+    public FeatureValue2(String contents) {
+      this.contents = contents;
+    }
+
+    public String getContents2() {
+      return contents;
+    }
+
+    @Override
+    public String toString() {
+      return "FeatureValue2{contents='" + contents + "'}";
+    }
   }
 }

--- a/src/test/java/com/linkedin/feathr/offline/plugins/AlienFeatureValue.java
+++ b/src/test/java/com/linkedin/feathr/offline/plugins/AlienFeatureValue.java
@@ -1,0 +1,58 @@
+package com.linkedin.feathr.offline.plugins;
+
+import java.util.Objects;
+
+public class AlienFeatureValue {
+  private final Float floatValue;
+  private final String stringValue;
+
+  private AlienFeatureValue(Float floatValue, String stringValue) {
+    this.floatValue = floatValue;
+    this.stringValue = stringValue;
+  }
+
+  public static AlienFeatureValue fromFloat(float floatValue) {
+    return new AlienFeatureValue(floatValue, null);
+  }
+
+  public static AlienFeatureValue fromString(String stringValue) {
+    return new AlienFeatureValue(null, stringValue);
+  }
+
+  public boolean isFloat() {
+    return floatValue != null;
+  }
+
+  public boolean isString() {
+    return stringValue != null;
+  }
+
+  public float getFloatValue() {
+    return Objects.requireNonNull(floatValue);
+  }
+
+  public String getStringValue() {
+    return Objects.requireNonNull(stringValue);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AlienFeatureValue that = (AlienFeatureValue) o;
+    return Objects.equals(floatValue, that.floatValue) && Objects.equals(stringValue, that.stringValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(floatValue, stringValue);
+  }
+
+  @Override
+  public String toString() {
+    return "AlienFeatureValue{" +
+        "floatValue=" + floatValue +
+        ", stringValue='" + stringValue + '\'' +
+        '}';
+  }
+}

--- a/src/test/java/com/linkedin/feathr/offline/plugins/AlienFeatureValueMvelUDFs.java
+++ b/src/test/java/com/linkedin/feathr/offline/plugins/AlienFeatureValueMvelUDFs.java
@@ -1,0 +1,29 @@
+package com.linkedin.feathr.offline.plugins;
+
+public class AlienFeatureValueMvelUDFs {
+  private AlienFeatureValueMvelUDFs() { }
+
+  public static AlienFeatureValue sqrt_afv(AlienFeatureValue input) {
+    return AlienFeatureValue.fromFloat((float) Math.sqrt(input.getFloatValue()));
+  }
+
+  public static AlienFeatureValue sqrt_float(float input) {
+    return AlienFeatureValue.fromFloat((float) Math.sqrt(input));
+  }
+
+  public static AlienFeatureValue uppercase_string_afv(AlienFeatureValue input) {
+    return AlienFeatureValue.fromString(input.getStringValue().toUpperCase());
+  }
+
+  public static AlienFeatureValue uppercase_string(String input) {
+    return AlienFeatureValue.fromString(input.toUpperCase());
+  }
+
+  public static AlienFeatureValue lowercase_string_afv(AlienFeatureValue input) {
+    return AlienFeatureValue.fromString(input.getStringValue().toLowerCase());
+  }
+
+  public static AlienFeatureValue lowercase_string(String input) {
+    return AlienFeatureValue.fromString(input.toLowerCase());
+  }
+}

--- a/src/test/java/com/linkedin/feathr/offline/plugins/AlienFeatureValueTypeAdaptor.java
+++ b/src/test/java/com/linkedin/feathr/offline/plugins/AlienFeatureValueTypeAdaptor.java
@@ -1,0 +1,29 @@
+package com.linkedin.feathr.offline.plugins;
+
+import com.linkedin.feathr.common.FeatureValue;
+import com.linkedin.feathr.common.types.NumericFeatureType;
+import com.linkedin.feathr.offline.mvel.plugins.FeatureValueTypeAdaptor;
+
+public class AlienFeatureValueTypeAdaptor implements FeatureValueTypeAdaptor<AlienFeatureValue> {
+  @Override
+  public FeatureValue toFeathrFeatureValue(AlienFeatureValue other) {
+    if (other.isFloat()) {
+      return FeatureValue.createNumeric(other.getFloatValue());
+    } else if (other.isString()) {
+      return FeatureValue.createCategorical(other.getStringValue());
+    } else {
+      throw new RuntimeException();
+    }
+  }
+
+  @Override
+  public AlienFeatureValue fromFeathrFeatureValue(FeatureValue featureValue) {
+    if (featureValue.getFeatureType().equals(NumericFeatureType.INSTANCE)) {
+      return AlienFeatureValue.fromFloat(featureValue.getAsNumeric());
+    } else {
+      // Unclear whether old FeatureValue API makes it very easy to determine whether feature is actual a CATEGORICAL,
+      // so for purposes of testing the plugin API, don't worry about it and just assume.
+      return AlienFeatureValue.fromString(featureValue.getAsCategorical());
+    }
+  }
+}

--- a/src/test/java/com/linkedin/feathr/offline/plugins/FeathrFeatureValueMvelUDFs.java
+++ b/src/test/java/com/linkedin/feathr/offline/plugins/FeathrFeatureValueMvelUDFs.java
@@ -1,0 +1,23 @@
+package com.linkedin.feathr.offline.plugins;
+
+import com.linkedin.feathr.common.FeatureValue;
+
+public class FeathrFeatureValueMvelUDFs {
+  private FeathrFeatureValueMvelUDFs() { }
+
+  public static FeatureValue inverse_ffv(FeatureValue input) {
+    return FeatureValue.createNumeric(1f / input.getAsNumeric());
+  }
+
+  public static FeatureValue inverse_float(float input) {
+    return FeatureValue.createNumeric(1f / input);
+  }
+
+  public static FeatureValue duplicate_string_ffv(FeatureValue input) {
+    return FeatureValue.createCategorical(input.getAsCategorical() + input.getAsCategorical());
+  }
+
+  public static FeatureValue duplicate_string(String input) {
+    return FeatureValue.createCategorical(input + input);
+  }
+}

--- a/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
+++ b/src/test/scala/com/linkedin/feathr/offline/AnchoredFeaturesIntegTest.scala
@@ -4,6 +4,8 @@ import com.linkedin.feathr.common.configObj.configbuilder.ConfigBuilderException
 import com.linkedin.feathr.common.exception.FeathrConfigException
 import com.linkedin.feathr.offline.generation.SparkIOUtils
 import com.linkedin.feathr.offline.job.PreprocessedDataFrameManager
+import com.linkedin.feathr.offline.mvel.plugins.FeathrMvelPluginContext
+import com.linkedin.feathr.offline.plugins.{AlienFeatureValue, AlienFeatureValueTypeAdaptor}
 import com.linkedin.feathr.offline.source.dataloader.{AvroJsonDataLoader, CsvDataLoader}
 import com.linkedin.feathr.offline.util.FeathrTestUtils
 import org.apache.spark.sql.Row

--- a/src/test/scala/com/linkedin/feathr/offline/TestFeathr.scala
+++ b/src/test/scala/com/linkedin/feathr/offline/TestFeathr.scala
@@ -4,6 +4,8 @@ import com.linkedin.feathr.common
 import com.linkedin.feathr.common.JoiningFeatureParams
 import com.linkedin.feathr.offline.client.FeathrClient
 import com.linkedin.feathr.offline.config.{FeathrConfig, FeathrConfigLoader}
+import com.linkedin.feathr.offline.mvel.plugins.FeathrMvelPluginContext
+import com.linkedin.feathr.offline.plugins.{AlienFeatureValue, AlienFeatureValueTypeAdaptor}
 import com.linkedin.feathr.offline.util.FeathrTestUtils
 import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.conf.Configuration
@@ -27,6 +29,7 @@ abstract class TestFeathr extends TestNGSuite {
 
   @BeforeClass
   def setup(): Unit = {
+    FeathrMvelPluginContext.addFeatureTypeAdaptor(classOf[AlienFeatureValue], new AlienFeatureValueTypeAdaptor)
     setupSpark()
   }
 

--- a/src/test/scala/com/linkedin/feathr/offline/TestFeathrUdfPlugins.scala
+++ b/src/test/scala/com/linkedin/feathr/offline/TestFeathrUdfPlugins.scala
@@ -1,0 +1,117 @@
+package com.linkedin.feathr.offline
+
+import com.linkedin.feathr.offline.mvel.plugins.FeathrMvelPluginContext
+import com.linkedin.feathr.offline.plugins.{AlienFeatureValue, AlienFeatureValueTypeAdaptor}
+import org.testng.annotations.Test
+
+class TestFeathrUdfPlugins extends FeathrIntegTest {
+
+  val MULTILINE_QUOTE = "\"\"\""
+
+  @Test
+  def testMvelUdfPluginSupport: Unit = {
+    FeathrMvelPluginContext.addFeatureTypeAdaptor(classOf[AlienFeatureValue], new AlienFeatureValueTypeAdaptor())
+
+    val df = runLocalFeatureJoinForTest(
+      joinConfigAsString = """
+                             | features: {
+                             |   key: a_id
+                             |   featureList: ["f1", "f2", "f3", "f4", "f5", "f6", "f7"]
+                             | }
+      """.stripMargin,
+      featureDefAsString = s"""
+                             |anchors: {
+                             |  anchor1: {
+                             |    source: "anchor1-source.csv"
+                             |    key: "mId"
+                             |    features: {
+                             |      // create an alien-type feature value, and expect Feathr to consume it via plugin
+                             |      f1: $MULTILINE_QUOTE
+                             |          import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |          AlienFeatureValueMvelUDFs.sqrt_float(gamma)
+                             |          $MULTILINE_QUOTE
+                             |
+                             |      // create an alien-type feature value, and pass it to a UDF that expects Feathr feature value
+                             |      f2: $MULTILINE_QUOTE
+                             |          import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |          import com.linkedin.feathr.offline.plugins.FeathrFeatureValueMvelUDFs;
+                             |          FeathrFeatureValueMvelUDFs.inverse_ffv(AlienFeatureValueMvelUDFs.sqrt_float(gamma))
+                             |          $MULTILINE_QUOTE
+                             |
+                             |      // create a Feathr feature value, and pass it to a UDF that expects the alien feature value
+                             |      f3: $MULTILINE_QUOTE
+                             |          import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |          import com.linkedin.feathr.offline.plugins.FeathrFeatureValueMvelUDFs;
+                             |          AlienFeatureValueMvelUDFs.sqrt_afv(FeathrFeatureValueMvelUDFs.inverse_float(gamma))
+                             |          $MULTILINE_QUOTE
+                             |
+                             |      f4: {
+                             |        type: CATEGORICAL
+                             |        def: $MULTILINE_QUOTE
+                             |          import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |          AlienFeatureValueMvelUDFs.uppercase_string(alpha);
+                             |          $MULTILINE_QUOTE
+                             |      }
+                             |    }
+                             |  }
+                             |}
+                             |
+                             |derivations: {
+                             |  // use an UDF that expects/returns alien-valued feature value
+                             |  f5: {
+                             |    type: NUMERIC
+                             |    definition: $MULTILINE_QUOTE
+                             |      import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |      AlienFeatureValueMvelUDFs.sqrt_float(f3)
+                             |      $MULTILINE_QUOTE
+                             |  }
+                             |  f6: {
+                             |     type: NUMERIC
+                             |     definition: $MULTILINE_QUOTE
+                             |       import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |       AlienFeatureValueMvelUDFs.sqrt_float(f2)
+                             |       $MULTILINE_QUOTE
+                             |  }
+                             |  f7: {
+                             |     type: CATEGORICAL
+                             |     definition: $MULTILINE_QUOTE
+                             |       import com.linkedin.feathr.offline.plugins.AlienFeatureValueMvelUDFs;
+                             |       AlienFeatureValueMvelUDFs.lowercase_string_afv(f4);
+                             |       $MULTILINE_QUOTE
+                             |  }
+                             |}
+        """.stripMargin,
+      observationDataPath = "anchorAndDerivations/testMVELLoopExpFeature-observations.csv")
+
+    df.data.show()
+
+    // TODO UPDATE THE EXPECTED DF BELOW
+//    val selectedColumns = Seq("a_id", "featureWithNull")
+//    val filteredDf = df.data.select(selectedColumns.head, selectedColumns.tail: _*)
+//
+//    val expectedDf = ss.createDataFrame(
+//      ss.sparkContext.parallelize(
+//        Seq(
+//          Row(
+//            // a_id
+//            "1",
+//            // featureWithNull
+//            1.0f),
+//          Row(
+//            // a_id
+//            "2",
+//            // featureWithNull
+//            0.0f),
+//          Row(
+//            // a_id
+//            "3",
+//            // featureWithNull
+//            3.0f))),
+//      StructType(
+//        List(
+//          StructField("a_id", StringType, true),
+//          StructField("featureWithNull", FloatType, true))))
+//    def cmpFunc(row: Row): String = row.get(0).toString
+//    FeathrTestUtils.assertDataFrameApproximatelyEquals(filteredDf, expectedDf, cmpFunc)
+  }
+}


### PR DESCRIPTION
The purpose of this API is for advanced users/deployments of Feathr to be able to use their own custom Scala UDF types for their feature anchors. This is intended as a migration aid from previous versions of Feathr (before open sourcing).