### PR TITLE
update token fetch for the registry and synapse

### DIFF
--- a/feathr_project/feathr/registry/_feathr_registry_client.py
+++ b/feathr_project/feathr/registry/_feathr_registry_client.py
@@ -189,7 +189,7 @@ class _FeatureRegistry(FeathrRegistry):
         return check(requests.post(f"{self.endpoint}{path}", headers=self._get_auth_header(), json=body)).json()
 
     def _get_auth_header(self) -> dict:
-        return {"Authorization": f'Bearer {self.credential.get_token(".default")}'}
+        return {"Authorization": f'Bearer {self.credential.get_token("https://dev.azuresynapse.net/.default").token}'}
     
     @classmethod
     def _get_py_files(self, path: Path) -> List[Path]:

--- a/feathr_project/feathr/registry/_feathr_registry_client.py
+++ b/feathr_project/feathr/registry/_feathr_registry_client.py
@@ -189,7 +189,7 @@ class _FeatureRegistry(FeathrRegistry):
         return check(requests.post(f"{self.endpoint}{path}", headers=self._get_auth_header(), json=body)).json()
 
     def _get_auth_header(self) -> dict:
-        return {"Authorization": f'Bearer {self.credential.get_token("https://dev.azuresynapse.net/.default").token}'}
+        return {"Authorization": f'Bearer {self.credential.get_token("https://management.azure.com/.default").token}'}
     
     @classmethod
     def _get_py_files(self, path: Path) -> List[Path]:

--- a/feathr_project/feathr/spark_provider/_synapse_submission.py
+++ b/feathr_project/feathr/spark_provider/_synapse_submission.py
@@ -326,7 +326,7 @@ class _SynapseJobRunner(object):
         # @see: https://docs.microsoft.com/en-us/azure/synapse-analytics/spark/connect-monitor-azure-synapse-spark-application-level-metrics
         app_id = self.get_spark_batch_job(job_id).app_id
         url = "%s/sparkhistory/api/v1/sparkpools/%s/livyid/%s/applications/%s/driverlog/stdout/?isDownload=true" % (self._synapse_dev_url, self._spark_pool_name, job_id, app_id)
-        token = self._credential.get_token("https://dev.azuresynapse.net/.default")
+        token = self._credential.get_token("https://dev.azuresynapse.net/.default").token
         req = urllib.request.Request(url=url, headers={"authorization": "Bearer %s" % token})
         resp = urllib.request.urlopen(req)
         return resp.read()


### PR DESCRIPTION
This PR contains changes to the following:

- DefaultAzureCredentials.get_token method returns an AccessToken object. the ".token" needs to be added to grab the string value of the token in the AccessToken object. 
- The ".default" url throws authentication error in the Feathr registry client when running the notebook, however, replacing the url with "https://dev.azuresynapse.net/.default" resolves the issue. More investigation is needed as to why.

<img width="1728" alt="Screen Shot 2022-07-22 at 2 14 41 PM" src="https://user-images.githubusercontent.com/105448774/181141795-040f9883-1acb-4c8c-b17c-32dbf02ab459.png">
 