### PR TITLE
Enable azure cli generated token from client

### DIFF
--- a/registry/access_control/rbac/models.py
+++ b/registry/access_control/rbac/models.py
@@ -12,6 +12,7 @@ class User(BaseModel):
 
 class UserType(str, Enum):
     AAD_USER = "aad_user",
+    USER_IMPERSONATION = "user_impersonation"
     AAD_APP = "aad_application",
     COMMON_USER = "common_user",
     UNKNOWN = "unknown",


### PR DESCRIPTION
User may use az login in feathr client and call registry with the `user_impersonation` token generated with Azure CLI.
Update auth.py to process this kind of tokens correctly. 

Another PR to fix token scope ("https://management.azure.com") in feathr client will be submitted to make the above update e2e functional. 