### PR TITLE
Extend Access Control Management APIs to Project Admins

### DIFF
--- a/registry/access_control/README.md
+++ b/registry/access_control/README.md
@@ -35,6 +35,10 @@ Users needs to create a `userroles` table with [schema.sql](scripts/schema.sql) 
 ### Initialize `userroles` records
 
 In current version, user needs to manually initialize `userroles` table admins in SQL table.
+At least one `global admin` is needed to use rbac features. You can add `[your-email-account]` as global admin with the following SQL script in [Azure portal query editor](https://docs.microsoft.com/en-us/azure/azure-sql/database/connect-query-portal?view=azuresql)
+```SQL
+insert into userroles (project_name, user_name, role_name, create_by, create_reason, create_time) values ('global', '[your-email-account]','admin', '[your-email-account]', 'test data',  getutcdate())
+```
 When `create_registry` and `create_project` API is enabled, default admin role will be assigned to the creator.
 Admin roles can add or delete roles in management UI page or through management API.
 
@@ -42,14 +46,14 @@ Admin roles can add or delete roles in management UI page or through management 
 
 `ENABLE_RBAC` needs to be set to deploy a registry backend with access control plugin.
 
-| Variable| Description|
-|---|---|
-| RBAC_CONNECTION_STR| Connection String of the SQL database that host access control tables, required.|
-| RBAC_API_BASE| Aligned API base|
-| RBAC_REGISTRY_URL| The downstream Registry API Endpoint|
-| RBAC_AAD_INSTANCE | Instance like "https://login.microsoftonline.com" |
-| RBAC_AAD_TENANT_ID| Used get auth url together with `RBAC_AAD_INSTANCE`|
-| RBAC_API_AUDIENCE| Used as audience to decode jwt tokens|
+| Variable            | Description                                                                      |
+| ------------------- | -------------------------------------------------------------------------------- |
+| RBAC_CONNECTION_STR | Connection String of the SQL database that host access control tables, required. |
+| RBAC_API_BASE       | Aligned API base                                                                 |
+| RBAC_REGISTRY_URL   | The downstream Registry API Endpoint                                             |
+| RBAC_AAD_INSTANCE   | Instance like "https://login.microsoftonline.com"                                |
+| RBAC_AAD_TENANT_ID  | Used get auth url together with `RBAC_AAD_INSTANCE`                              |
+| RBAC_API_AUDIENCE   | Used as audience to decode jwt tokens                                            |
 
 ## Notes
 
@@ -67,12 +71,12 @@ Supported scenarios status are tracked below:
   - [x] Initialize default Project Admin role for project creator
   - [ ] Initialize default Global Admin Role for workspace creator
 - UI Experience
-  - [x] Hidden page `../management` for global admin to make CUD requests to `userroles` table
+  - [x] Hidden page `../management` for project admin to make CUD requests to `userroles` table
   - [x] Use id token in Management API Request headers to identify requestor
 - Future Enhancements:
   - [x] Support AAD Application token  
   - [x] Support OAuth tokens with `email` attributes
-  - [ ] Functional in Feathr Client
+  - [x] Functional in Feathr Client
   - [ ] Support AAD Groups
   - [ ] Support Other OAuth Providers
   

--- a/registry/access_control/README.md
+++ b/registry/access_control/README.md
@@ -37,10 +37,10 @@ Users needs to create a `userroles` table with [schema.sql](scripts/schema.sql) 
 In current version, user needs to manually initialize `userroles` table admins in SQL table.
 At least one `global admin` is needed to use rbac features. You can add `[your-email-account]` as global admin with the following SQL script in [Azure portal query editor](https://docs.microsoft.com/en-us/azure/azure-sql/database/connect-query-portal?view=azuresql)
 ```SQL
-insert into userroles (project_name, user_name, role_name, create_by, create_reason, create_time) values ('global', '[your-email-account]','admin', '[your-email-account]', 'test data',  getutcdate())
+insert into userroles (project_name, user_name, role_name, create_by, create_reason, create_time) values ('global', '[your-email-account]','admin', '[your-email-account]', 'Initialize First Global Admin',  getutcdate())
 ```
 When `create_registry` and `create_project` API is enabled, default admin role will be assigned to the creator.
-Admin roles can add or delete roles in management UI page or through management API.
+Admin roles can add or delete roles in management UI page or through management API under certain scope.
 
 ### Environment Settings
 

--- a/registry/access_control/README.md
+++ b/registry/access_control/README.md
@@ -34,12 +34,13 @@ Users needs to create a `userroles` table with [schema.sql](scripts/schema.sql) 
 
 ### Initialize `userroles` records
 
-In current version, user needs to manually initialize `userroles` table admins in SQL table.
-At least one `global admin` is needed to use rbac features. You can add `[your-email-account]` as global admin with the following SQL script in [Azure portal query editor](https://docs.microsoft.com/en-us/azure/azure-sql/database/connect-query-portal?view=azuresql)
+In current version, user needs to manually initialize `userroles` table in SQL database with [schema.sql](scripts/schema.sql) and insert global admin roles.
+You can add `[your-email-account]` as global admin with the following SQL script in [Azure portal query editor](https://docs.microsoft.com/en-us/azure/azure-sql/database/connect-query-portal?view=azuresql)
 ```SQL
 insert into userroles (project_name, user_name, role_name, create_by, create_reason, create_time) values ('global', '[your-email-account]','admin', '[your-email-account]', 'Initialize First Global Admin',  getutcdate())
 ```
-When `create_registry` and `create_project` API is enabled, default admin role will be assigned to the creator.
+
+When a feathr project is created though rbac protected registry API, default project admin role will be assigned to the creator.
 Admin roles can add or delete roles in management UI page or through management API under certain scope.
 
 ### Environment Settings

--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -14,34 +14,35 @@ registry_url = config.RBAC_REGISTRY_URL
 
 @router.get('/projects', name="Get a list of Project Names [No Auth Required]")
 async def get_projects() -> list[str]:
-    response = requests.get(registry_url + "/projects").content.decode('utf-8')
+    response = requests.get(
+        url=f"{registry_url}/projects").content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get('/projects/{project}', name="Get My Project [Read Access Required]")
 async def get_project(project: str, requestor: User = Depends(project_read_access)):
-    response = requests.get(registry_url + "/projects/" + project,
+    response = requests.get(url=f"{registry_url}/projects/{project}",
                             headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/datasources", name="Get data sources of my project [Read Access Required]")
 def get_project_datasources(project: str, requestor: User = Depends(project_read_access)) -> list:
-    response = requests.get(registry_url + "/projects/" + project + "/datasources",
+    response = requests.get(url=f"{registry_url}/projects/{project}/datasources",
                             headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/features", name="Get features under my project [Read Access Required]")
 def get_project_features(project: str, keyword: Optional[str] = None, requestor: User = Depends(project_read_access)) -> list:
-    response = requests.get(registry_url + "/projects/" + project + "/features",
+    response = requests.get(url=f"{registry_url}/projects/{project}/features",
                             headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/features/{feature}", name="Get a single feature by feature Id [Read Access Required]")
 def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = requests.get(registry_url + "/features/" + feature,
+    response = requests.get(url=f"{registry_url}/features/{feature}",
                             headers=get_api_header(requestor)).content.decode('utf-8')
     ret = json.loads(response)
 
@@ -53,7 +54,7 @@ def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
 
 @router.get("/features/{feature}/lineage", name="Get Feature Lineage [Read Access Required]")
 def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = requests.get(registry_url + "/features/" + feature + "/lineage",
+    response = requests.get(url=f"{registry_url}/features/{feature}/lineage",
                             headers=get_api_header(requestor)).content.decode('utf-8')
     ret = json.loads(response)
 
@@ -66,35 +67,35 @@ def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> di
 @router.post("/projects", name="Create new project with definition [Auth Required]")
 def new_project(definition: dict, requestor: User = Depends(get_user)) -> dict:
     rbac.init_userrole(requestor, definition["name"])
-    response = requests.post(url=registry_url + "/projects", params=definition,
+    response = requests.post(url=f"{registry_url}/projects", params=definition,
                              headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/datasources", name="Create new data source of my project [Write Access Required]")
 def new_project_datasource(project: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url=registry_url + "/projects/" + project + '/datasources',
-                             params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=f"{registry_url}/projects/{project}/datasources", params=definition, headers=get_api_header(
+        requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/anchors", name="Create new anchors of my project [Write Access Required]")
 def new_project_anchor(project: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url=registry_url + "/projects/" + project + '/datasources',
-                             params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=f"{registry_url}/projects/{project}/anchors", params=definition, headers=get_api_header(
+        requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/anchors/{anchor}/features", name="Create new anchor features of my project [Write Access Required]")
 def new_project_anchor_feature(project: str, anchor: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url=registry_url + "/projects/" + project + '/anchors/' + anchor +
-                             '/features', params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=f"{registry_url}/projects/{project}/anchors/{anchor}/features", params=definition, headers=get_api_header(
+        requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/derivedfeatures", name="Create new derived features of my project [Write Access Required]")
 def new_project_derived_feature(project: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url=registry_url + "/projects/" + project + '/derivedfeatures',
+    response = requests.post(url=f"{registry_url}/projects/{project}/derivedfeatures",
                              params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 

--- a/registry/access_control/api.py
+++ b/registry/access_control/api.py
@@ -11,6 +11,7 @@ router = APIRouter()
 rbac = DbRBAC()
 registry_url = config.RBAC_REGISTRY_URL
 
+
 @router.get('/projects', name="Get a list of Project Names [No Auth Required]")
 async def get_projects() -> list[str]:
     response = requests.get(registry_url + "/projects").content.decode('utf-8')
@@ -19,79 +20,97 @@ async def get_projects() -> list[str]:
 
 @router.get('/projects/{project}', name="Get My Project [Read Access Required]")
 async def get_project(project: str, requestor: User = Depends(project_read_access)):
-    response = requests.get(registry_url + "/projects/" + project, headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.get(registry_url + "/projects/" + project,
+                            headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/datasources", name="Get data sources of my project [Read Access Required]")
 def get_project_datasources(project: str, requestor: User = Depends(project_read_access)) -> list:
-    response = requests.get(registry_url + "/projects/" + project + "/datasources", headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.get(registry_url + "/projects/" + project + "/datasources",
+                            headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.get("/projects/{project}/features", name="Get features under my project [Read Access Required]")
 def get_project_features(project: str, keyword: Optional[str] = None, requestor: User = Depends(project_read_access)) -> list:
-    response = requests.get(registry_url + "/projects/" + project + "/features", headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.get(registry_url + "/projects/" + project + "/features",
+                            headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
+
 
 @router.get("/features/{feature}", name="Get a single feature by feature Id [Read Access Required]")
 def get_feature(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = requests.get(registry_url + "/features/" + feature, headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.get(registry_url + "/features/" + feature,
+                            headers=get_api_header(requestor)).content.decode('utf-8')
     ret = json.loads(response)
 
     feature_qualifiedName = ret['attributes']['qualifiedName']
-    validate_project_access_for_feature(feature_qualifiedName, requestor, AccessType.READ)
+    validate_project_access_for_feature(
+        feature_qualifiedName, requestor, AccessType.READ)
     return ret
+
 
 @router.get("/features/{feature}/lineage", name="Get Feature Lineage [Read Access Required]")
 def get_feature_lineage(feature: str, requestor: User = Depends(get_user)) -> dict:
-    response = requests.get(registry_url + "/features/" + feature + "/lineage", headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.get(registry_url + "/features/" + feature + "/lineage",
+                            headers=get_api_header(requestor)).content.decode('utf-8')
     ret = json.loads(response)
 
     feature_qualifiedName = ret['guidEntityMap'][feature]['attributes']['qualifiedName']
-    validate_project_access_for_feature(feature_qualifiedName, requestor, AccessType.READ)
+    validate_project_access_for_feature(
+        feature_qualifiedName, requestor, AccessType.READ)
     return ret
+
 
 @router.post("/projects", name="Create new project with definition [Auth Required]")
 def new_project(definition: dict, requestor: User = Depends(get_user)) -> dict:
     rbac.init_userrole(requestor, definition["name"])
-    response = requests.post(url = registry_url + "/projects", params=definition, headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=registry_url + "/projects", params=definition,
+                             headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
+
 
 @router.post("/projects/{project}/datasources", name="Create new data source of my project [Write Access Required]")
 def new_project_datasource(project: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url = registry_url + "/projects/" + project + '/datasources', params=definition, headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=registry_url + "/projects/" + project + '/datasources',
+                             params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
+
 
 @router.post("/projects/{project}/anchors", name="Create new anchors of my project [Write Access Required]")
 def new_project_anchor(project: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url = registry_url + "/projects/" + project + '/datasources', params=definition, headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=registry_url + "/projects/" + project + '/datasources',
+                             params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/anchors/{anchor}/features", name="Create new anchor features of my project [Write Access Required]")
 def new_project_anchor_feature(project: str, anchor: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url = registry_url + "/projects/" + project + '/anchors/' + anchor + '/features', params=definition, headers = get_api_header(requestor)).content.decode('utf-8')
+    response = requests.post(url=registry_url + "/projects/" + project + '/anchors/' + anchor +
+                             '/features', params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 
 @router.post("/projects/{project}/derivedfeatures", name="Create new derived features of my project [Write Access Required]")
-def new_project_derived_feature(project: str,definition: dict, requestor: User = Depends(project_write_access)) -> dict:
-    response = requests.post(url = registry_url + "/projects/" + project + '/derivedfeatures', params=definition, headers = get_api_header(requestor)).content.decode('utf-8')
+def new_project_derived_feature(project: str, definition: dict, requestor: User = Depends(project_write_access)) -> dict:
+    response = requests.post(url=registry_url + "/projects/" + project + '/derivedfeatures',
+                             params=definition, headers=get_api_header(requestor)).content.decode('utf-8')
     return json.loads(response)
 
 # Below are access control management APIs
-@router.get("/userroles", name="List all active user role records [Global Admin Required]")
-def get_userroles(requestor: User = Depends(global_admin_access)) -> list:
-    return list([r.to_dict() for r in rbac.userroles])
 
 
-@router.post("/users/{user}/userroles/add", name="Add a new user role [Global Admin Required]")
-def add_userrole(project: str, user: str, role: str, reason: str, requestor: User = Depends(global_admin_access)):
+@router.get("/userroles", name="List all active user role records [Project Manage Access Required]")
+def get_userroles(requestor: User = Depends(get_user)) -> list:
+    return rbac.list_userroles(requestor.username)
+
+
+@router.post("/users/{user}/userroles/add", name="Add a new user role [Project Manage Access Required]")
+def add_userrole(project: str, user: str, role: str, reason: str, requestor: User = Depends(project_manage_access)):
     return rbac.add_userrole(project, user, role, reason, requestor.username)
 
 
-@router.delete("/users/{user}/userroles/delete", name="Delete a user role [Global Admin Required]")
-def delete_userrole(project: str, user: str, role: str, reason: str, requestor: User = Depends(global_admin_access)):
+@router.delete("/users/{user}/userroles/delete", name="Delete a user role [Project Manage Access Required]")
+def delete_userrole(project: str, user: str, role: str, reason: str, requestor: User = Depends(project_manage_access)):
     return rbac.delete_userrole(project, user, role, reason, requestor.username)
-


### PR DESCRIPTION
This PR includes:
- Update 3 management APIs to authorize project admin rather than global admin
- Update readme to reveal this change

*Many changes in this PR are caused by autoformat. *
