### PR TITLE
Rename link check CI job name

### DIFF
--- a/.github/workflows/document-scan.yml
+++ b/.github/workflows/document-scan.yml
@@ -2,7 +2,7 @@ name: Feathr Documents' Broken Link Check
 
 on: [push]
 jobs:
-  Explore-GitHub-Actions:
+  check-links:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR renames CI link checker job name from Explore-GitHub-Actions to check-links. 