### PR TITLE
Move feathr ui live demo section to root README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,6 +131,13 @@ Read [Point-in-time Correctness and Point-in-time Join in Feathr](https://linked
 
 Follow the [quick start Jupyter Notebook](./samples/product_recommendation_demo.ipynb) to try it out. There is also a companion [quick start guide](https://linkedin.github.io/feathr/quickstart_synapse.html) containing a bit more explanation on the notebook.
 
+### Feathr UI
+
+You can use Feathr UI to search features, identify data sources, track feature lineages and manage access controls. Check out the latest live demo [here](https://aka.ms/feathrdemo) to see what Feathr UI can do for you. Use one of following accounts when you are prompted to login:
+
+- A work or school organization account, includes Office 365 subscribers.
+- Microsoft personal account, this means an account can access to Skype, Outlook.com, OneDrive, and Xbox LIVE.
+
 ## 🗣️ Tech Talks on Feathr
 
 - [Introduction to Feathr - Beginner's guide](https://www.youtube.com/watch?v=gZg01UKQMTY)

--- a/ui/README.md
+++ b/ui/README.md
@@ -2,13 +2,6 @@
 
 This directory hosts Feathr Feature Store UI code.
 
-## Live Demo
-
-Check out the latest Feathr Feature Store UI live demo [here](https://aka.ms/feathrdemo), use one of following accounts when you are prompted to login:
-
-- A work or school organization account, includes Office 365 subscribers.
-- Microsoft personal account, this means an account can access to Skype, Outlook.com, OneDrive, and Xbox LIVE.
-
 ## Development Getting Started
 
 ### Prerequisites


### PR DESCRIPTION
This PR moves Feathr UI live demo section from /ui/README.md (target UI devs) to /docs/README.md (targets end users).