### PR TITLE
Fix FeatureJoinJob parameters not correctly printed in spark job log

### DIFF
--- a/src/main/scala/com/linkedin/feathr/offline/job/FeatureJoinJob.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/job/FeatureJoinJob.scala
@@ -335,7 +335,7 @@ object FeatureJoinJob {
   }
 
   def main(args: Array[String]) {
-    logger.info("FeatureJoinJob args are: " + args)
+    logger.info("FeatureJoinJob args are: " + args.mkString("Array(", ", ", ")"))
     val feathrJoinPreparationInfo = prepareSparkSession(args)
 
     run(feathrJoinPreparationInfo.sparkSession, feathrJoinPreparationInfo.hadoopConf, feathrJoinPreparationInfo.jobContext, List()) //TODO: accept handlers instead of empty List


### PR DESCRIPTION
This PR fixes FeatureJoinJob parameters not correctly printed in spark job log