### PR TITLE
Read existing custom tags from databricks config template

### DIFF
--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -149,7 +149,14 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
             configuration['spark.executor.extraJavaOptions'] = '-Djava.security.properties='
             configuration['spark.driver.extraJavaOptions'] = '-Djava.security.properties='
             submission_params['new_cluster']['spark_conf'] = configuration
-            submission_params['new_cluster']['custom_tags'] = job_tags
+
+            if job_tags:
+                custom_tags = submission_params['new_cluster'].get('custom_tags', {})
+                for tag, value in job_tags.items():
+                    custom_tags[tag] = value
+
+                submission_params['new_cluster']['custom_tags'] = custom_tags
+
         # the feathr main jar file is anyway needed regardless it's pyspark or scala spark
         if not main_jar_path:
             logger.info(f"Main JAR file is not set, using default package '{FEATHR_MAVEN_ARTIFACT}' from Maven")


### PR DESCRIPTION
In order to create a new data bricks cluster, we are required to set a series of custom tags. It did not seem like this was directly configurable. 

This was less than 20 lines, so I wanted to share what I did to get it working. It seems like there are a few different ways to do this and I would love to learn of an existing way I missed or contribute a PR to add functionality. 

I will post this in slack and we can discuss there.