### PR TITLE
Clear Feathr UDF state and configuration template in work directory

### DIFF
--- a/feathr_project/feathr/client.py
+++ b/feathr_project/feathr/client.py
@@ -245,7 +245,7 @@ class FeathrClient(object):
 
         # Pretty print anchor_list
         if verbose and self.anchor_list:
-                FeaturePrinter.pretty_print_anchors(self.anchor_list)
+            FeaturePrinter.pretty_print_anchors(self.anchor_list)
 
     def list_registered_features(self, project_name: str = None) -> List[str]:
         """List all the already registered features under the given project.

--- a/feathr_project/feathr/registry/_feature_registry_purview.py
+++ b/feathr_project/feathr/registry/_feature_registry_purview.py
@@ -357,7 +357,7 @@ class _PurviewRegistry(FeathrRegistry):
             ts (TopologicalSorter): a topological sorter by python
 
         Returns:
-            None. The topo sorter will maitain a static topo sorted order.
+            None. The topological sorter will maintain a static topological sorted order.
         """
         # return if the list is empty
         if derived_features is None:
@@ -366,7 +366,7 @@ class _PurviewRegistry(FeathrRegistry):
         for derived_feature in derived_features:
             # make sure the input is derived feature
             if isinstance(derived_feature, DerivedFeature):
-                # add this derived feature in the topo sort graph without any precessesors
+                # add this derived feature in the topological sort graph without any predecessors
                 # since regardless we need it
                 ts.add(derived_feature)
                 for input_feature in derived_feature.input_features:
@@ -394,12 +394,12 @@ class _PurviewRegistry(FeathrRegistry):
         ts = TopologicalSorter()
 
         self._add_all_derived_features(derived_features, ts)
-        # topo sort the derived features to make sure that we can correctly refer to them later in the registry
+        # topological sort the derived features to make sure that we can correctly refer to them later in the registry
         toposorted_derived_feature_list: List[DerivedFeature] = list(ts.static_order())
         
         for derived_feature in toposorted_derived_feature_list:
             # get the corresponding Atlas entity by searching feature name
-            # Since this list is topo sorted, so you can always find the corresponding name
+            # Since this list is topological sorted, so you can always find the corresponding name
             input_feature_entity_list: List[AtlasEntity] = [
                 self.global_feature_entity_dict[f.name] for f in derived_feature.input_features]
             key_list = []
@@ -713,9 +713,9 @@ derivations: {
 
     def upload_single_entity_to_purview(self,entity:Union[AtlasEntity,AtlasProcess]):
         '''
-        Upload a single entity to purview, could be a process entity or atlasentity. 
+        Upload a single entity to purview, could be a process entity or AtlasEntity. 
         Since this is used for migration existing project, ignore Atlas PreconditionFail (412)
-        If the eneity already exists, return the existing entity's GUID.
+        If the entity already exists, return the existing entity's GUID.
         Otherwise, return the new entity GUID.
         The entity itself will also be modified, fill the GUID with real GUID in Purview.
         In order to avoid having concurrency issue, and provide clear guidance, this method only allows entity uploading once at a time.
@@ -809,7 +809,7 @@ derivations: {
         anchor_entity = self.purview_client.get_entity(anchor_id)['entities'][0]
 
         
-        # project contians anchor, anchor belongs to project.
+        # project contains anchor, anchor belongs to project.
         project_contains_anchor_relation = self._generate_relation_pairs(
             project_entity, anchor_entity, RELATION_CONTAINS)
         anchor_consumes_source_relation = self._generate_relation_pairs(
@@ -946,7 +946,7 @@ derivations: {
 
     def _delete_all_feathr_types(self):
         """
-        Delete all the corresonding type definitions for feathr registry. For internal use only
+        Delete all the corresponding type definitions for feathr registry. For internal use only
         """
         typedefs = self.purview_client.get_all_typedefs()
 
@@ -967,18 +967,18 @@ derivations: {
 
     def _delete_all_feathr_entities(self):
         """
-        Delete all the corresonding entity for feathr registry. For internal use only
+        Delete all the corresponding entity for feathr registry. For internal use only
 
         :param guid: The guid or guids you want to remove.
         """
         # should not be large than this, otherwise the backend might throw out error
-        batch_delte_size = 100
+        batch_delete_size = 100
 
-        # use the `query` API so that it can return immediatelly (don't use the search_entity API as it will try to return all the results in a single request)
+        # use the `query` API so that it can return immediately (don't use the search_entity API as it will try to return all the results in a single request)
 
         while True:
             result = self.purview_client.discovery.query(
-                "feathr", limit=batch_delte_size)
+                "feathr", limit=batch_delete_size)
             logger.info("Total number of entities:",result['@search.count'] )
 
             # if no results, break:
@@ -987,7 +987,7 @@ derivations: {
             entities = result['value']
             guid_list = [entity["id"] for entity in entities]
             self.purview_client.delete_entity(guid=guid_list)
-            logger.info("{} feathr entities deleted", batch_delte_size)
+            logger.info("{} feathr entities deleted", batch_delete_size)
             # sleep here, otherwise backend might throttle
             # process the next batch after sleep
             sleep(1)
@@ -1237,7 +1237,7 @@ derivations: {
                                     name=source_entity["attributes"]["name"],
                                     event_timestamp_column=source_entity["attributes"]["event_timestamp_column"],
                                     timestamp_format=source_entity["attributes"]["timestamp_format"],
-                                    preprocessing=self._correct_function_identation(source_entity["attributes"]["preprocessing"]),
+                                    preprocessing=self._correct_function_indentation(source_entity["attributes"]["preprocessing"]),
                                     path=source_entity["attributes"]["path"],
                                     registry_tags=source_entity["attributes"]["tags"]
                                     ),
@@ -1264,9 +1264,9 @@ derivations: {
         return result
 
 
-    def _correct_function_identation(self, user_func: str) -> str:
+    def _correct_function_indentation(self, user_func: str) -> str:
         """
-        The function read from registry might have the wrong identation. We need to correct those identations.
+        The function read from registry might have the wrong indentation. We need to correct those indentation.
         More specifically, we are using the inspect module to copy the function body for UDF for further submission. In that case, there will be situations like this:
 
         def feathr_udf1(df)
@@ -1302,7 +1302,7 @@ derivations: {
         return HdfsSource(name=source_entity["attributes"]["name"],
                 event_timestamp_column=source_entity["attributes"]["event_timestamp_column"],
                 timestamp_format=source_entity["attributes"]["timestamp_format"],
-                preprocessing=self._correct_function_identation(source_entity["attributes"]["preprocessing"]),
+                preprocessing=self._correct_function_indentation(source_entity["attributes"]["preprocessing"]),
                 path=source_entity["attributes"]["path"],
                 registry_tags=source_entity["attributes"]["tags"]
                 )

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -1,25 +1,23 @@
-import base64
+import copy
 import json
 import os
 import time
-
 from collections import namedtuple
 from os.path import basename
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import requests
+from databricks_cli.dbfs.api import DbfsApi
+from databricks_cli.runs.api import RunsApi
+from databricks_cli.sdk.api_client import ApiClient
+from feathr.constants import *
+from feathr.spark_provider._abc import SparkJobLauncher
 from loguru import logger
 from requests.structures import CaseInsensitiveDict
-from tqdm import tqdm
 
-from feathr.spark_provider._abc import SparkJobLauncher
-from feathr.constants import *
-from databricks_cli.dbfs.api import DbfsApi
-from databricks_cli.sdk.api_client import ApiClient
-from databricks_cli.runs.api import RunsApi
 
 class _FeathrDatabricksJobLauncher(SparkJobLauncher):
     """Class to interact with Databricks Spark cluster
@@ -137,8 +135,10 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
             # if the input is a string, load it directly
             submission_params = json.loads(self.config_template)
         else:
-            # otherwise users might have missed the quotes in the config.
-            submission_params = self.config_template
+            # otherwise users might have missed the quotes in the config. Treat them as dict
+            # Note that we need to use deep copy here, in order to make `self.config_template` immutable
+            # Otherwise, since we need to change submission_params later, which will modify `self.config_template` and cause unexpected behaviors
+            submission_params = copy.deepcopy(self.config_template) 
 
         submission_params['run_name'] = job_name
         if 'existing_cluster_id' not in submission_params:
@@ -161,6 +161,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
             # the first file is the pyspark driver code. we only need the driver code to execute pyspark
             param_and_file_dict = {"parameters": arguments, "python_file": self.upload_or_get_cloud_path(python_files[0])}
             # indicates this is a pyspark job
+            # `setdefault` method will get the value of the "spark_python_task" item, if the "spark_python_task" item does not exist, insert "spark_python_task" with the value "param_and_file_dict":
             submission_params.setdefault('spark_python_task',param_and_file_dict)
         else:
             # this is a scala spark job

--- a/feathr_project/feathr/spark_provider/_databricks_submission.py
+++ b/feathr_project/feathr/spark_provider/_databricks_submission.py
@@ -139,7 +139,6 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
         else:
             # otherwise users might have missed the quotes in the config.
             submission_params = self.config_template
-            logger.warning("Databricks config template loaded in a non-string fashion. Please consider providing the config template in a string fashion.")
 
         submission_params['run_name'] = job_name
         if 'existing_cluster_id' not in submission_params:
@@ -161,6 +160,7 @@ class _FeathrDatabricksJobLauncher(SparkJobLauncher):
             # this is a pyspark job. definition here: https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/2.0/jobs#--sparkpythontask
             # the first file is the pyspark driver code. we only need the driver code to execute pyspark
             param_and_file_dict = {"parameters": arguments, "python_file": self.upload_or_get_cloud_path(python_files[0])}
+            # indicates this is a pyspark job
             submission_params.setdefault('spark_python_task',param_and_file_dict)
         else:
             # this is a scala spark job

--- a/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
@@ -37,9 +37,13 @@ class _PreprocessingPyudfManager(object):
         features_with_preprocessing = []
         client_udf_repo_path = os.path.join(local_workspace_dir, FEATHR_CLIENT_UDF_FILE_NAME)
         metadata_path = os.path.join(local_workspace_dir, FEATHR_PYSPARK_METADATA)
+        pyspark_driver_path = os.path.join(local_workspace_dir, FEATHR_PYSPARK_DRIVER_FILE_NAME)
+
         # delete the file if it already exists to avoid caching previous results
-        os.remove(client_udf_repo_path) if os.path.exists(client_udf_repo_path) else None
-        os.remove(metadata_path) if os.path.exists(metadata_path) else None
+        for f in [client_udf_repo_path, metadata_path,  pyspark_driver_path]:
+            if os.path.exists(f):
+                os.remove(f) 
+
         for anchor in anchor_list:
             # only support batch source preprocessing for now.
             if not hasattr(anchor.source, "preprocessing"):
@@ -156,7 +160,7 @@ feature_names_funcs = {
         if not features_with_preprocessing:
             return py_udf_files
 
-        # Figure out if we need to preprocessing via UDFs for requested features.
+        # Figure out if we need to preprocess via UDFs for requested features.
         # Only if the requested features contain preprocessing logic, we will load Pyspark. Otherwise just use Scala
         # spark.
         has_py_udf_preprocessing = False
@@ -171,6 +175,9 @@ feature_names_funcs = {
             # write pyspark_driver_template_abs_path and then client_udf_repo_path
             filenames = [pyspark_driver_template_abs_path, client_udf_repo_path]
             # will always overwrite the old files so it's fine not removing it
+            if os.path.exists(pyspark_driver_path):
+                os.remove(pyspark_driver_path) 
+                
             with open(pyspark_driver_path, 'w') as outfile:
                 for fname in filenames:
                     with open(fname) as infile:

--- a/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
@@ -174,9 +174,6 @@ feature_names_funcs = {
             client_udf_repo_path = os.path.join(local_workspace_dir, FEATHR_CLIENT_UDF_FILE_NAME)
             # write pyspark_driver_template_abs_path and then client_udf_repo_path
             filenames = [pyspark_driver_template_abs_path, client_udf_repo_path]
-            # will always overwrite the old files so it's fine not removing it
-            if os.path.exists(pyspark_driver_path):
-                os.remove(pyspark_driver_path) 
                 
             with open(pyspark_driver_path, 'w') as outfile:
                 for fname in filenames:

--- a/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
@@ -170,6 +170,7 @@ feature_names_funcs = {
             client_udf_repo_path = os.path.join(local_workspace_dir, FEATHR_CLIENT_UDF_FILE_NAME)
             # write pyspark_driver_template_abs_path and then client_udf_repo_path
             filenames = [pyspark_driver_template_abs_path, client_udf_repo_path]
+            # will always overwrite the old files so it's fine not removing it
             with open(pyspark_driver_path, 'w') as outfile:
                 for fname in filenames:
                     with open(fname) as infile:

--- a/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
+++ b/feathr_project/feathr/udf/_preprocessing_pyudf_manager.py
@@ -112,7 +112,7 @@ class _PreprocessingPyudfManager(object):
 
         # Append to file, Create it if doesn't exist
         with open(client_udf_repo_path, "a+") as handle:
-                print("".join(lines), file=handle)
+            print("".join(lines), file=handle)
 
     @staticmethod
     def write_feature_names_to_udf_name_file(feature_names_to_func_mapping, local_workspace_dir):

--- a/feathr_project/feathr/utils/_file_utils.py
+++ b/feathr_project/feathr/utils/_file_utils.py
@@ -8,9 +8,7 @@ def write_to_file(content: str, full_file_name: str):
         content: content to write into the file
         full_file_name: full file path
     """
-    file_name_start = full_file_name.rfind("/")
-    if file_name_start > 0:
-        dir_name = full_file_name[:file_name_start]
-        Path(dir_name).mkdir(parents=True, exist_ok=True)
+    dir_name = os.path.dirname(full_file_name)
+    Path(dir_name).mkdir(parents=True, exist_ok=True)
     with open(full_file_name, "w") as handle:
         print(content, file=handle)

--- a/src/main/scala/com/linkedin/feathr/offline/generation/outputProcessor/RedisOutputUtils.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/generation/outputProcessor/RedisOutputUtils.scala
@@ -24,7 +24,7 @@ object RedisOutputUtils {
     val outputKeyColumnName = "feature_key"
     val decoratedDf = encodedDf.withColumn(outputKeyColumnName, newColExpr)
       .drop(keyColumns: _*)
-
+    print(decoratedDf.show())
     // set the host/post/auth/ssl configs in Redis again in the output directly
     // otherwise, in some environment (like databricks), the configs from the active spark session is not passed here.
     decoratedDf.write

--- a/src/main/scala/com/linkedin/feathr/offline/generation/outputProcessor/RedisOutputUtils.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/generation/outputProcessor/RedisOutputUtils.scala
@@ -24,7 +24,6 @@ object RedisOutputUtils {
     val outputKeyColumnName = "feature_key"
     val decoratedDf = encodedDf.withColumn(outputKeyColumnName, newColExpr)
       .drop(keyColumns: _*)
-    print(decoratedDf.show())
     // set the host/post/auth/ssl configs in Redis again in the output directly
     // otherwise, in some environment (like databricks), the configs from the active spark session is not passed here.
     decoratedDf.write


### PR DESCRIPTION
# The first issue
In the existing code, we didn't remove `generated_feathr_pyspark_metadata` when building the features. This is problematic in a few end users, in particular: If UDFs are defined and then are removed, since this file is not cleared, the code will still think there are UDFs, which will either yield wrong results, or exist incorrectly. 

This PR makes sure that we remove `generated_feathr_pyspark_metadata` and a few UDF files every time users build features.


# The second issue (#559 )
This is an issue which isn't very obvious. Sometimes after running `get_offline_features`, then running `materialize_features` API, the `materialize_features` API will not be successful, and in many cases there's no values in the online store such as Redis.

This only happens when using databricks. 

This is caused by the fact that if the databricks configuration is not a string (i.e. end users use a dict to provide all the required configurations), then there's a line in the code

`submission_params = self.config_template`

Since self.config_template is a dict, this is actually a reference rather than a copy of `self.config_template`. In the code later, `submission_params` will be modified and the value will be carried over across jobs, which will cause different jobs share the same state, and will cause unexpected behaviors.

# Other issues
This PR also fixes a few OS compatibility issues (when parsing paths we always assume it's Linux style which isn't true), and fix a few typos. 

