### PR TITLE
Optimize purview query for getting features

### DIFF
--- a/registry/purview-registry/main.py
+++ b/registry/purview-registry/main.py
@@ -64,18 +64,8 @@ def get_project_datasources(project: str) -> list:
 
 @router.get("/projects/{project}/features",tags=["Project"])
 def get_project_features(project: str, keyword: Optional[str] = None) -> list:
-    if keyword is None or keyword.strip()=='':
-        p = registry.get_entity(project,True)
-        feature_ids = [s.id for s in p.attributes.anchor_features] + \
-            [s.id for s in p.attributes.derived_features]
-        features = registry.get_entities(feature_ids,True)
-        return list([to_camel(e.to_dict()) for e in features])
-    else:
-        efs = registry.search_entity(
-            keyword, [EntityType.AnchorFeature, EntityType.DerivedFeature],project=project)
-        feature_ids = [ef.id for ef in efs]
-        features = registry.get_entities(feature_ids)
-        return list([to_camel(e.to_dict()) for e in features])
+    atlasEntities = registry.get_project_features(project, keywords=keyword)
+    return list([to_camel(e.to_dict()) for e in atlasEntities])
 
 
 @router.get("/features/{feature}",tags=["Feature"])

--- a/registry/purview-registry/registry/purview_registry.py
+++ b/registry/purview-registry/registry/purview_registry.py
@@ -189,13 +189,30 @@ class PurviewRegistry(Registry):
         names = name.split(self.registry_delimiter)
         return Edge(guid, names[1], names[2], RelationshipType.new(names[0]))
 
+    def get_project_features(self, project:str, keywords:Optional[str] = None) -> list[Entity]:
+        project_id = self.get_entity_id(project)
+        if not project_id:
+            return None
+        guidAtlasEntityMap = self.purview_client.get_entity_lineage(project_id, depth=1, width=1, direction="OUTPUT")['guidEntityMap']
+        atlasEntities = []
+
+        for entity in guidAtlasEntityMap.values():
+            type = entity['typeName']
+            if type != "Process":
+                type = EntityType.new(type)
+                if type == EntityType.AnchorFeature or type == EntityType.DerivedFeature:
+                    attributes = entity['attributes']
+                    if not keywords or (attributes and keywords in attributes['qualifiedName']):
+                        atlasEntity = self._atlasEntity_to_entity(entity)
+                        atlasEntities.append(atlasEntity)
+        return atlasEntities
+
     def get_project(self, id_or_name: Union[str, UUID]) -> EntitiesAndRelations:
         project_id = self.get_entity_id(id_or_name)
         if not project_id:
             return None
         lineage = self.purview_client.get_entity_lineage(project_id)
         guidAtlasEntityMap = lineage['guidEntityMap']
-
         guidEntityMap = {}
         finalGuidEntityMap = {}
         edges = []
@@ -249,7 +266,7 @@ class PurviewRegistry(Registry):
         Search entities with specified type that also match the keyword in a project
         """
         query_result = self.purview_client.search_entities(keyword)
-        result = []
+        result = []   
         for entity in query_result:
             qualified_name = entity["qualifiedName"]
             entity_id = entity['id']
@@ -592,4 +609,5 @@ class PurviewRegistry(Registry):
         for entity in entities:
             if entity.get('qualifiedName') == qualifiedName:
                 return entity.get('id')
-                
+
+


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/linkedin/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal. Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #564 

- Modify 'get_project_features' API to reduce time consuming
- Main idea is calling only one purview client API to avoid too many HTTP requests
- Performance comparison:
Input
  start = time.time()
  features = registry.get_project_features("enya_test_registry")
  feature_list=list([to_camel(e.to_dict()) for e in features])
  print("duration1: ", time.time()-start)
  start = time.time()
  features = registry.get_project_features_origin("enya_test_registry")
  feature_list=list([to_camel(e.to_dict()) for e in features])
  print("duration2: ", time.time()-start)
Output: 
duration1:  2.2548649311065674
duration2:  16.783140897750854


## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.