### PR TITLE
Fix source entity missing time window bug.

### DIFF
--- a/feathr_project/feathr/registry/registry_utils.py
+++ b/feathr_project/feathr/registry/registry_utils.py
@@ -59,8 +59,10 @@ def source_to_def(v: Source) -> dict:
         ret["preprocessing"] = inspect.getsource(v.preprocessing)
     if v.event_timestamp_column:
         ret["eventTimestampColumn"] = v.event_timestamp_column
+        ret["event_timestamp_column"] = v.event_timestamp_column
     if v.timestamp_format:
         ret["timestampFormat"] = v.timestamp_format
+        ret["timestamp_format"] = v.timestamp_format
     if v.registry_tags:
         ret["tags"] = v.registry_tags
     return ret


### PR DESCRIPTION
The bug is about source entity missing time window information. turns out timestamp column and timestamp format. 
These properties are lost when saving to purview.
Add these columns back, to avoid breaking other pipeline, do not remove these camel case properties.