### PR TITLE
Print lineage endpoint link in log after registering features

### DIFF
--- a/feathr_project/feathr/registry/_feathr_registry_client.py
+++ b/feathr_project/feathr/registry/_feathr_registry_client.py
@@ -2,6 +2,7 @@ import importlib
 import inspect
 import json
 import logging
+from loguru import logger
 import os
 from pathlib import Path
 import sys
@@ -25,7 +26,6 @@ from feathr.definition.transformation import ExpressionTransformation, Transform
 from feathr.definition.typed_key import TypedKey
 from feathr.registry.feature_registry import FeathrRegistry
 from feathr.utils._file_utils import write_to_file
-
 
 def to_camel(s):
     if not s:
@@ -122,6 +122,8 @@ class _FeatureRegistry(FeathrRegistry):
         for df in _topological_sort(derived_feature_list):
             if not hasattr(df, "_registry_id"):
                 df._registry_id = self._create_derived_feature(df)
+        url = '/'.join(self.endpoint.split('/')[:3])       
+        logger.info(f"Check project lineage by this link: {url}/projects/{self.project_name}/lineage")
 
     def list_registered_features(self, project_name: str) -> List[str]:
         """List all the already registered features. If project_name is not provided or is None, it will return all


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/linkedin/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal. Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

- Print out link to check project lineage after registering features in log so that customers can check it conveniently
- The log would look like:
   2022-08-26 16:12:04.175 | INFO     | feathr.registry._feathr_registry_client:register_features:126 - Check project lineage 
   by this link: https://feathr-purview-registry.azurewebsites.net/projects/registry_test_enya_3/lineage

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.