### PR TITLE
Hotfix for feathr runtime jar fails with Spark error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ val jdbcDrivers = Seq(
 lazy val root = (project in file("."))
   .settings(
       name := "feathr",
-      // To assemble, run sbt assembly -java-home /Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home
+      // To assemble, run sbt assembly -java-home /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
       assembly / mainClass := Some("com.linkedin.feathr.offline.job.FeatureJoinJob"),
       libraryDependencies ++= cloudProvidedDeps,
       libraryDependencies ++= localAndCloudCommonDependencies,
@@ -73,7 +73,7 @@ lazy val root = (project in file("."))
 //lazy val localCliJar = (project in file("."))
 // .settings(
 //     name := "feathr-cli",
-//     // To assemble, run sbt assembly -java-home /Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home
+//     // To assemble, run sbt assembly -java-home /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
 //     assembly / mainClass := Some("com.linkedin.feathr.cli.FeatureExperimentEntryPoint"),
 //     // assembly / mainClass := Some("com.linkedin.feathr.offline.job.FeatureJoinJob"),
 //     libraryDependencies ++= localAndCloudDiffDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / resolvers += Resolver.mavenLocal
 ThisBuild / scalaVersion     := "2.12.15"
-ThisBuild / version          := "0.7.0"
+ThisBuild / version          := "0.7.1"
 ThisBuild / organization     := "com.linkedin.feathr"
 ThisBuild / organizationName := "linkedin"
 val sparkVersion = "3.1.3"

--- a/docs/dev_guide/publish_to_maven.md
+++ b/docs/dev_guide/publish_to_maven.md
@@ -82,7 +82,6 @@ parent: Developer Guides
         *   ```
             sbt -java-home /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
             ```
-        * This will ensure compiled jar won't fail at runtime with error `java.lang.UnsupportedClassVersionError: com/linkedin/feathr/common/exception/FeathrInputDataException has been compiled by a more recent version of the Java Runtime (class file version 62.0), this version of the Java Runtime only recognizes class file versions up to 52.0`
     * Execute command in sbt console to publish to maven
         *   ```
             reload; publishSigned; sonatypeBundleRelease
@@ -97,7 +96,7 @@ parent: Developer Guides
 
 ## Troubleshooting
 - If you get something like `[error] gpg: signing failed: Inappropriate ioctl for device`, run `export GPG_TTY=$(tty)` in your terminal and restart sbt console.
-
+- If the published jar fails to run in Spark with error `java.lang.UnsupportedClassVersionError: com/linkedin/feathr/common/exception/FeathrInputDataException has been compiled by a more recent version of the Java Runtime (class file version 62.0), this version of the Java Runtime only recognizes class file versions up to 52.0`, make sure you complied with the right Java version with -java-home parameter in sbt console.
 
 ## CI Automatic Publishing
 

--- a/docs/dev_guide/publish_to_maven.md
+++ b/docs/dev_guide/publish_to_maven.md
@@ -80,12 +80,9 @@ parent: Developer Guides
             ```
     * Start sbt console by running
         *   ```
-            sbt
+            sbt -java-home /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
             ```
-        * if experiencing java issues try setting the java version like so:
-            *   ```
-                sbt -java-home /Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home
-                ```
+        * This will ensure compiled jar won't fail at runtime with error `java.lang.UnsupportedClassVersionError: com/linkedin/feathr/common/exception/FeathrInputDataException has been compiled by a more recent version of the Java Runtime (class file version 62.0), this version of the Java Runtime only recognizes class file versions up to 52.0`
     * Execute command in sbt console to publish to maven
         *   ```
             reload; publishSigned; sonatypeBundleRelease

--- a/feathr_project/feathr/constants.py
+++ b/feathr_project/feathr/constants.py
@@ -28,4 +28,4 @@ TYPEDEF_ARRAY_ANCHOR=f"array<feathr_anchor_{REGISTRY_TYPEDEF_VERSION}>"
 TYPEDEF_ARRAY_DERIVED_FEATURE=f"array<feathr_derived_feature_{REGISTRY_TYPEDEF_VERSION}>"
 TYPEDEF_ARRAY_ANCHOR_FEATURE=f"array<feathr_anchor_feature_{REGISTRY_TYPEDEF_VERSION}>"
 
-FEATHR_MAVEN_ARTIFACT="com.linkedin.feathr:feathr_2.12:0.7.0"
+FEATHR_MAVEN_ARTIFACT="com.linkedin.feathr:feathr_2.12:0.7.1"

--- a/feathr_project/setup.py
+++ b/feathr_project/setup.py
@@ -7,7 +7,7 @@ long_description = (root_path / "docs/README.md").read_text()
 
 setup(
     name='feathr',
-    version='0.7.0',
+    version='0.7.1',
     long_description=long_description,
     long_description_content_type="text/markdown",
     author_email="frame_dev@linkedin.com",

--- a/feathr_project/test/test_user_workspace/feathr_config.yaml
+++ b/feathr_project/test/test_user_workspace/feathr_config.yaml
@@ -82,7 +82,7 @@ spark_config:
     # Feathr Job configuration. Support local paths, path start with http(s)://, and paths start with abfs(s)://
     # this is the default location so end users don't have to compile the runtime again.
     # feathr_runtime_location: wasbs://public@azurefeathrstorage.blob.core.windows.net/feathr-assembly-LATEST.jar
-    feathr_runtime_location: "../../target/scala-2.12/feathr-assembly-0.7.0.jar"
+    feathr_runtime_location: "../../target/scala-2.12/feathr-assembly-0.7.1.jar"
   databricks:
     # workspace instance
     workspace_instance_url: 'https://adb-2474129336842816.16.azuredatabricks.net/'
@@ -93,7 +93,7 @@ spark_config:
     # Feathr Job location. Support local paths, path start with http(s)://, and paths start with dbfs:/
     work_dir: 'dbfs:/feathr_getting_started'
     # this is the default location so end users don't have to compile the runtime again.
-    feathr_runtime_location: "../../target/scala-2.12/feathr-assembly-0.7.0.jar"
+    feathr_runtime_location: "../../target/scala-2.12/feathr-assembly-0.7.1.jar"
 
 online_store:
   redis:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1") //https://github.com/sbt/sbt-
  * Supports more advanced dependency tree scripts
  * 
  * ex.
- * sbt dependencyTree -java-home /Library/Java/JavaVirtualMachines/jdk1.8.0_282-msft.jdk/Contents/Home
+ * sbt dependencyTree -java-home /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
  * https://www.baeldung.com/scala/sbt-dependency-tree
  */
 addDependencyTreePlugin


### PR DESCRIPTION
## Description
<!--
Hey! Thank you for the contribution! Please go through https://github.com/linkedin/feathr/blob/main/docs/dev_guide/pull_request_guideline.md for more information.

Describe
- What changes to make and why you are making these changes.
- How are you going to achieve your goal. Describe what testings you have done, for example, performance testing etc.

If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Hotfix v0.7.0 runtime jar fails with Spark error:

`java.lang.UnsupportedClassVersionError: com/linkedin/feathr/common/exception/FeathrInputDataException has been compiled by a more recent version of the Java Runtime (class file version 62.0), this version of the Java Runtime only recognizes class file versions up to 52.0`

## How was this PR tested?
<!--
If you're unsure about what to test, where to add tests, or how to run tests, please feel free to ask. We'd be happy to help.
-->

New maven version v0.7.1 published, extract jar and verified compiled java version by command:
`
file ./0.7.1/com/linkedin/feathr/common/exception/FeathrInputDataException.class
`
result:
`
./0.7.1/com/linkedin/feathr/common/exception/FeathrInputDataException.class: compiled Java class data, version 52.0 (Java 1.8)
`
## Does this PR introduce any user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, choose 'No'.
-->
- [x] No. You can skip the rest of this section.
- [ ] Yes. Make sure to clarify your proposed changes.