### PR TITLE
Windoze/elasticsearch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,7 @@ val localAndCloudCommonDependencies = Seq(
     "org.xerial" % "sqlite-jdbc" % "3.36.0.3",
     "com.github.changvvb" %% "jackson-module-caseclass" % "1.1.1",
     "com.azure.cosmos.spark" % "azure-cosmos-spark_3-1_2-12" % "4.11.1",
+    "org.elasticsearch" % "elasticsearch-spark-30_2.12" % "7.15.2",
     "org.eclipse.jetty" % "jetty-util" % "9.3.24.v20180605"
 ) // Common deps
 

--- a/docs/how-to-guides/jdbc-cosmos-notes.md
+++ b/docs/how-to-guides/jdbc-cosmos-notes.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Using SQL databases and CosmosDb with Feathr
+title: Using SQL databases, CosmosDb, and ElasticSearch with Feathr
 parent: Feathr How-to Guides
 ---
 
@@ -103,3 +103,43 @@ container_client = db_client.get_container_client(some_cosmosdb_collection)
 doc = container_client.read_item(some_key)
 feature_value = doc['feature_name']
 ```
+
+## Using ElasticSearch as online store
+
+To use ElasticSearch as the online store, create `ElasticSearchSink` and add it to the `MaterializationSettings`, then use it with `FeathrClient.materialize_features`, e.g..
+
+```
+name = 'es_output'
+sink = ElasticSearchSink(name, host="esnode1:9200", index="someindex", ssl=False, auth=True)
+os.environ[f"{name.upper()}_USER"] = "some_user_name"
+os.environ[f"{name.upper()}_PASSWORD"] = "some_magic_word"
+client.materialize_features(..., materialization_settings=MaterializationSettings(..., sinks=[sink]))
+```
+
+Feathr client doesn't support getting feature values from ElasticSearch, you need to use [official ElasticSearch client](https://pypi.org/project/elasticsearch/) to get the values, e.g.:
+
+```
+from elasticsearch import Elasticsearch
+
+es = Elasticsearch("http://esnode1:9200")
+resp = es.get(index="someindex", id="somekey")
+print(resp['_source'])
+```
+
+NOTE:
++ You can use no auth or basic auth only, no other authentication methods are supported.
++ If you enabled SSL, you need to make sure the certificate on ES nodes is trusted by the Spark cluster, otherwise the job will fail.
+
+## Using ElasticSearch as offline store
+
+To use ElasticSearch as the offline store, create `ElasticSearchSink` and use it with `FeathrClient.get_offline_features`, e.g..
+
+```
+name = 'es_output'
+sink = ElasticSearchSink(name, host="esnode1", index="someindex", ssl=False, auth=True)
+os.environ[f"{name.upper()}_USER"] = "some_user_name"
+os.environ[f"{name.upper()}_PASSWORD"] = "some_magic_word"
+client.get_offline_features(..., output_path=sink)
+```
+
+NOTE: The feature joining process doesn't generate meaningful keys for each document, you need to make sure the output dataset can be accessed/queried by some other ways such as full-text-search, otherwise you may have to fetch all the data from ES to get what you look for.

--- a/feathr_project/feathr/definition/sink.py
+++ b/feathr_project/feathr/definition/sink.py
@@ -288,19 +288,30 @@ class ElasticSearchSink(GenericSink):
     def __init__(self,
                  name: str,
                  host: str,
-                 port: str,
                  index: str,
                  ssl: bool = True,
                  auth: bool = True,
                  mode = 'OVERWRITE'):
+        """
+        name: The name of the sink.
+        host: ElasticSearch node, can be `hostname` or `hostname:port`, default port is 9200.
+        index: The index to write the data.
+        ssl: Set to `True` to enable SSL.
+        auth: Set to `True` to enable authentication, you need to provide username/password from environment or KeyVault.
+        mode: Spark mode, check official doc for more details.
+        """
         self.auth = auth
         options = {
             'es.nodes': host,
-            'es.port': port,
             'es.ssl': str(ssl).lower(),
             'es.resource': index,
         }
         if auth:
+            """
+            Currently only BasicAuth is supported.
+            ElasticSearch Spark connector also supports PKI auth but that needs to setup keystore on each driver node,
+            which seems to be too complicated for managed Spark cluster.
+            """
             options["es.net.http.auth.user"] = "${%s_USER}" % name.upper(),
             options["es.net.http.auth.pass"] = "${%s_PASSWORD}" % name.upper(),
         super().__init__(name,

--- a/feathr_project/feathr/definition/source.py
+++ b/feathr_project/feathr/definition/source.py
@@ -349,5 +349,36 @@ class CosmosDbSource(GenericSource):
                          event_timestamp_column=event_timestamp_column, timestamp_format=timestamp_format,
                          registry_tags=registry_tags)
 
+class ElasticSearchSource(GenericSource):
+    """
+    Use ElasticSearch as the data source
+    """
+    def __init__(self,
+                 name: str,
+                 host: str,
+                 port: str,
+                 index: str,
+                 ssl: bool = True,
+                 auth: bool = True,
+                 preprocessing: Optional[Callable] = None,
+                 event_timestamp_column: Optional[str] = None,
+                 timestamp_format: Optional[str] = "epoch",
+                 registry_tags: Optional[Dict[str, str]] = None):
+        options = {
+            'es.nodes': host,
+            'es.port': port,
+            'es.ssl': str(ssl).lower(),
+            'es.resource': index,
+        }
+        if auth:
+            options["es.net.http.auth.user"] = "${%s_USER}" % name.upper(),
+            options["es.net.http.auth.pass"] = "${%s_PASSWORD}" % name.upper(),
+        super().__init__(name,
+                         format='org.elasticsearch.spark.sql',
+                         mode="APPEND",
+                         options=options,
+                         preprocessing=preprocessing,
+                         event_timestamp_column=event_timestamp_column, timestamp_format=timestamp_format,
+                         registry_tags=registry_tags)
 
 INPUT_CONTEXT = InputContext()

--- a/feathr_project/feathr/definition/source.py
+++ b/feathr_project/feathr/definition/source.py
@@ -356,7 +356,6 @@ class ElasticSearchSource(GenericSource):
     def __init__(self,
                  name: str,
                  host: str,
-                 port: str,
                  index: str,
                  ssl: bool = True,
                  auth: bool = True,
@@ -364,9 +363,16 @@ class ElasticSearchSource(GenericSource):
                  event_timestamp_column: Optional[str] = None,
                  timestamp_format: Optional[str] = "epoch",
                  registry_tags: Optional[Dict[str, str]] = None):
+        """
+        name: The name of the sink.
+        host: ElasticSearch node, can be `hostname` or `hostname:port`, default port is 9200.
+        index: The index to read the data.
+        ssl: Set to `True` to enable SSL.
+        auth: Set to `True` to enable authentication, you need to provide username/password from environment or KeyVault.
+        preprocessing/event_timestamp_column/timestamp_format/registry_tags: See `HdfsSource`
+        """
         options = {
             'es.nodes': host,
-            'es.port': port,
             'es.ssl': str(ssl).lower(),
             'es.resource': index,
         }

--- a/feathr_project/test/test_azure_spark_e2e.py
+++ b/feathr_project/test/test_azure_spark_e2e.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
-from feathr.definition.sink import CosmosDbSink
+from feathr.definition.sink import CosmosDbSink, ElasticSearchSink
 
 import pytest
 from click.testing import CliRunner
@@ -262,6 +262,36 @@ def test_feathr_materialize_to_cosmosdb():
                                            "f_location_avg_fare", "f_location_max_fare"],
                                        backfill_time=backfill_time)
     client.materialize_features(settings)
+    # assuming the job can successfully run; otherwise it will throw exception
+    client.wait_job_to_finish(timeout_sec=Constants.SPARK_JOB_TIMEOUT_SECONDS)
+
+
+@pytest.mark.skip(reason="Marked as skipped as we need to setup resources for this test")
+def test_feathr_materialize_to_es():
+    """
+    Test FeathrClient() CosmosDbSink.
+    """
+    test_workspace_dir = Path(
+        __file__).parent.resolve() / "test_user_workspace"
+    # os.chdir(test_workspace_dir)
+
+    client: FeathrClient = basic_test_setup(os.path.join(test_workspace_dir, "feathr_config.yaml"))
+
+    backfill_time = BackfillTime(start=datetime(
+        2020, 5, 20), end=datetime(2020, 5, 20), step=timedelta(days=1))
+
+    now = datetime.now()
+    index = ''.join(['feathrazure_cijob_materialize_','_', str(now.minute), '_', str(now.second), ""])
+    sink = ElasticSearchSink(name='es1', host='somenode:9200', index=index, ssl=True, auth=True)
+    settings = MaterializationSettings("nycTaxiTable",
+                                       sinks=[sink],
+                                       feature_names=[
+                                           "f_location_avg_fare", "f_location_max_fare"],
+                                       backfill_time=backfill_time)
+    client.materialize_features(settings)
+    # Set user and password before submitting job
+    # os.environ[f"es1_USER"] = "some_user"
+    # os.environ[f"es1_PASSWORD"] = "some_password"
     # assuming the job can successfully run; otherwise it will throw exception
     client.wait_job_to_finish(timeout_sec=Constants.SPARK_JOB_TIMEOUT_SECONDS)
 

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/DataLocation.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/DataLocation.scala
@@ -60,6 +60,7 @@ trait DataLocation {
 
   /**
    * Write DataFrame to the location
+   *
    * @param ss SparkSession
    * @param df DataFrame to write
    */
@@ -77,7 +78,12 @@ trait DataLocation {
 
 object LocationUtils {
   private def propOrEnvOrElse(key: String, alt: String): String = {
-    scala.util.Properties.propOrElse(key, scala.util.Properties.envOrElse(key, alt))
+    // Try properties, then env, then properties and env again with uppercase
+    // GitHub secrets must have uppercase name, so client can only use uppercase keys if they're taken from GH secrets
+    scala.util.Properties.propOrElse(key,
+      scala.util.Properties.envOrElse(key,
+        scala.util.Properties.propOrElse(key.toUpperCase,
+          scala.util.Properties.envOrElse(key.toUpperCase, alt))))
   }
 
   /**
@@ -108,6 +114,7 @@ object LocationUtils {
 object DataLocation {
   /**
    * Create DataLocation from string, try parsing the string as JSON and fallback to SimplePath
+   *
    * @param cfg the input string
    * @return DataLocation
    */
@@ -126,7 +133,7 @@ object DataLocation {
         SimplePath(cfg)
       }
     } catch {
-      case _ @ (_: ConfigException | _: JacksonException) => SimplePath(cfg)
+      case _@(_: ConfigException | _: JacksonException) => SimplePath(cfg)
     }
   }
 

--- a/src/main/scala/com/linkedin/feathr/offline/config/location/GenericLocation.scala
+++ b/src/main/scala/com/linkedin/feathr/offline/config/location/GenericLocation.scala
@@ -180,6 +180,7 @@ object GenericLocationAdHocPatches {
         keyDf.write.format(location.format)
           .option("es.nodes.wan.only", "true")
           .option("es.mapping.id", "_id") // Use generated key as the doc id
+          .option("es.mapping.exclude", "_id") // Exclude doc id column from the doc body
           .option("es.write.operation", "upsert") // As we already have `_id` column, we should use "upsert", otherwise there could be duplicates in the output
           .options(location.options)
           .mode(location.mode.getOrElse("overwrite")) // I don't see if ElasticSearch uses it in any doc

--- a/src/main/scala/com/linkedin/feathr/swj/transformer/FeatureTransformer.scala
+++ b/src/main/scala/com/linkedin/feathr/swj/transformer/FeatureTransformer.scala
@@ -93,6 +93,7 @@ object FeatureTransformer {
     // The order of the feature columns should follow the order of the specified sliding window
     // features. In addition, the feature columns should be in front of join key and timestamp
     // columns. These will guarantee we can fetch corresponding feature columns using index.
+    println(s"SQL: ${sql}")
     spark.sql(sql)
   }
 }


### PR DESCRIPTION
This PR enables using ElasticSearch as the online and offline store.

The CI test has been added but is currently marked as skipped because we need to setup ES cluster in our testing environment first.

The PR also enables using ElasticSearch as a source but I don't see any strong need for this usage, we can either hide it from the end users or remove this part.