### PR TITLE
HdfsSource type is always 'hdfs'

### DIFF
--- a/feathr_project/feathr/registry/_feathr_registry_client.py
+++ b/feathr_project/feathr/registry/_feathr_registry_client.py
@@ -433,16 +433,6 @@ def dict_to_source(v: dict) -> Source:
     source = None
     if type == INPUT_CONTEXT:
         source = InputContext()
-    elif v["attributes"]["type"] in ("wasbs", "wasb", "hdfs"):
-        source = HdfsSource(name=v["attributes"]["name"],
-                            path=v["attributes"]["path"],
-                            preprocessing=_correct_function_indentation(
-                                v["attributes"].get("preprocessing")),
-                            event_timestamp_column=v["attributes"].get(
-                                "eventTimestampColumn"),
-                            timestamp_format=v["attributes"].get(
-                                "timestampFormat"),
-                            registry_tags=v["attributes"].get("tags", {}))
     elif type == "jdbc":
         source = JdbcSource(name=v["attributes"]["name"],
                             url=v["attributes"].get("url"),
@@ -486,6 +476,16 @@ def dict_to_source(v: dict) -> Source:
             timestamp_format=v["attributes"].get(
                 "timestampFormat"),
             registry_tags=v["attributes"].get("tags", {}))
+    elif "path" in v["attributes"]:
+        source = HdfsSource(name=v["attributes"]["name"],
+                            path=v["attributes"]["path"],
+                            preprocessing=_correct_function_indentation(
+                                v["attributes"].get("preprocessing")),
+                            event_timestamp_column=v["attributes"].get(
+                                "eventTimestampColumn"),
+                            timestamp_format=v["attributes"].get(
+                                "timestampFormat"),
+                            registry_tags=v["attributes"].get("tags", {}))
     else:
         raise ValueError(f"Invalid source format {type}")
     source._registry_id = id

--- a/feathr_project/feathr/registry/_feathr_registry_client.py
+++ b/feathr_project/feathr/registry/_feathr_registry_client.py
@@ -476,7 +476,7 @@ def dict_to_source(v: dict) -> Source:
             timestamp_format=v["attributes"].get(
                 "timestampFormat"),
             registry_tags=v["attributes"].get("tags", {}))
-    elif "path" in v["attributes"]:
+    elif v["attributes"].get("path"):
         source = HdfsSource(name=v["attributes"]["name"],
                             path=v["attributes"]["path"],
                             preprocessing=_correct_function_indentation(

--- a/feathr_project/feathr/registry/registry_utils.py
+++ b/feathr_project/feathr/registry/registry_utils.py
@@ -38,7 +38,7 @@ def source_to_def(v: Source) -> dict:
     elif isinstance(v, HdfsSource):
         ret = {
             "name": v.name,
-            "type": urlparse(v.path).scheme,
+            "type": "hdfs",
             "path": v.path,
         }
     elif isinstance(v, JdbcSource):


### PR DESCRIPTION
Using `HdfsSource` with `path` set to `abfss:...` causes feature registration error.
The `type` of `HdfsSource` should always be `hdfs` instead of extracting from its path URL.
